### PR TITLE
Live pause - Matrix API change

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,26 +1,45 @@
 # build artifacts
 build/
+inputstream.*/addon.xml
+
+# Debian build files
 debian/changelog
 debian/files
-debian/kodi-inputstream-ffmpegarchive-dbg.debhelper.log
-debian/kodi-inputstream-ffmpegarchive-dbg.substvars
-debian/kodi-inputstream-ffmpegarchive-dbg/
-debian/kodi-inputstream-ffmpegarchive.debhelper.log
-debian/kodi-inputstream-ffmpegarchive.postinst.debhelper
-debian/kodi-inputstream-ffmpegarchive.postrm.debhelper
-debian/kodi-inputstream-ffmpegarchive.substvars
-debian/kodi-inputstream-ffmpegarchive/
+debian/*.log
+debian/*.substvars
+debian/.debhelper/
 debian/tmp/
+debian/kodi-pvr-*/
 obj-x86_64-linux-gnu/
-inputstream.ffmpegarchive/addon.xml
+
+# commonly used editors
+# vim
+*.swp
+
+# Eclipse
+*.project
+*.cproject
+.classpath
+*.sublime-*
+.settings/
+
+# KDevelop 4
+*.kdev4
+
+# gedit
+*~
+
+# CLion
+/.idea
 
 # clion
 .idea/
 
-# Eclipse/CDT
-.cproject
-.project
-.settings/
+# to prevent add after a "git format-patch VALUE" and "git add ." call
+/*.patch
 
-# VSCode
+# Visual Studio Code
 .vscode
+
+# to prevent add if project code opened by Visual Studio over CMake file
+.vs/

--- a/inputstream.ffmpegdirect/addon.xml.in
+++ b/inputstream.ffmpegdirect/addon.xml.in
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <addon
   id="inputstream.ffmpegdirect"
-  version="1.7.3"
+  version="1.8.0"
   name="Inputstream FFmpeg Direct"
   provider-name="phunkyfish">
   <requires>@ADDON_DEPENDS@</requires>
@@ -23,6 +23,12 @@
       <fanart>fanart.jpg</fanart>
     </assets>
     <news>
+v1.8.0
+- Added: Support live URL in addition to catchup URL
+- Added: Support resuming from pause and to catchup stream
+- Update: Remove CanSeekStream and CanPauseStream for Inputstream API v2.1.0
+- Update: .gitignore
+
 v1.7.3
 - Update: Remove pthreads library as now w32pthreads is used instead
 - Update: libxml2 disable unused components for common depends and remove unrequired patch

--- a/inputstream.ffmpegdirect/addon.xml.in
+++ b/inputstream.ffmpegdirect/addon.xml.in
@@ -10,7 +10,7 @@
     name="ffmpegdirect"
     extension=""
     tags="true"
-    listitemprops="mime_type|program_number|stream_mode|realtime_url|is_realtime_stream|playback_as_live|programme_start_time|programme_end_time|catchup_url_format_string|catchup_url_near_live_format_string|catchup_buffer_start_time|catchup_buffer_end_time|catchup_buffer_offset|timezone_shift|default_programme_duration|programme_catchup_id"
+    listitemprops="mime_type|program_number|stream_mode|default_url|is_realtime_stream|playback_as_live|programme_start_time|programme_end_time|catchup_url_format_string|catchup_url_near_live_format_string|catchup_buffer_start_time|catchup_buffer_end_time|catchup_buffer_offset|timezone_shift|default_programme_duration|programme_catchup_id"
     library_@PLATFORM@="@LIBRARY_FILENAME@" />
   <extension point="xbmc.addon.metadata">
     <summary lang="en_GB">InputStream Client for FFmpeg streams (libavformat)</summary>

--- a/inputstream.ffmpegdirect/changelog.txt
+++ b/inputstream.ffmpegdirect/changelog.txt
@@ -1,3 +1,9 @@
+v1.8.0
+- Added: Support live URL in addition to catchup URL
+- Added: Support resuming from pause and to catchup stream
+- Update: Remove CanSeekStream and CanPauseStream for Inputstream API v2.1.0
+- Update: .gitignore
+
 v1.7.3
 - Update: Remove pthreads library as now w32pthreads is used instead
 - Update: libxml2 disable unused components for common depends and remove unrequired patch

--- a/src/StreamManager.cpp
+++ b/src/StreamManager.cpp
@@ -261,16 +261,6 @@ bool CInputStreamLibavformat::SeekChapter(int ch)
   return m_stream->SeekChapter(ch);
 }
 
-bool CInputStreamLibavformat::CanPauseStream()
-{
-  return m_stream->CanPauseStream();
-}
-
-bool CInputStreamLibavformat::CanSeekStream()
-{
-  return m_stream->CanSeekStream();
-}
-
 int CInputStreamLibavformat::ReadStream(uint8_t* buf, unsigned int size)
 {
   return m_stream->ReadStream(buf, size);
@@ -293,7 +283,7 @@ int64_t CInputStreamLibavformat::LengthStream()
 
 void CInputStreamLibavformat::PauseStream(double time)
 {
-  return m_stream->PauseStream(time);
+  // Unused when inputsream has it's own demuxer
 }
 
 bool CInputStreamLibavformat::IsRealTimeStream()

--- a/src/StreamManager.h
+++ b/src/StreamManager.h
@@ -75,8 +75,6 @@ public:
   virtual int64_t GetChapterPos(int ch) override;
   virtual bool SeekChapter(int ch) override;
 
-  virtual bool CanPauseStream() override;
-  virtual bool CanSeekStream() override;
   virtual int ReadStream(uint8_t* buffer, unsigned int bufferSize) override;
   virtual int64_t SeekStream(int64_t position, int whence = SEEK_SET) override;
   virtual int64_t PositionStream() override;

--- a/src/stream/BaseStream.h
+++ b/src/stream/BaseStream.h
@@ -51,14 +51,10 @@ public:
   virtual int64_t GetChapterPos(int ch) = 0;
   virtual bool SeekChapter(int ch) = 0;
 
-
-  virtual bool CanPauseStream() = 0;
-  virtual bool CanSeekStream() = 0;
   virtual int ReadStream(uint8_t* buffer, unsigned int bufferSize) = 0;
   virtual int64_t SeekStream(int64_t position, int whence = SEEK_SET) = 0;
   virtual int64_t PositionStream() = 0;
   virtual int64_t LengthStream() = 0;
-  virtual void PauseStream(double time) = 0;
   virtual bool IsRealTimeStream() = 0;
 
 protected:

--- a/src/stream/FFmpegCatchupStream.cpp
+++ b/src/stream/FFmpegCatchupStream.cpp
@@ -161,9 +161,7 @@ int64_t FFmpegCatchupStream::SeekStream(int64_t position, int whence /* SEEK_SET
         }
         else
         {
-          // TODO we appear to require an extra 10 seconds less to skip hitting EOF
-          // There must be a cleaner solutiom than this.
-          ret = timeNow - m_catchupBufferStartTime - 10;
+          ret = timeNow - m_catchupBufferStartTime;
           m_catchupBufferOffset = ret;
         }
         ret *= DVD_TIME_BASE;

--- a/src/stream/FFmpegCatchupStream.h
+++ b/src/stream/FFmpegCatchupStream.h
@@ -31,14 +31,12 @@ public:
   virtual bool Open(const std::string& streamUrl, const std::string& mimeType, bool isRealTimeStream, const std::string& programProperty) override;
   virtual bool DemuxSeekTime(double time, bool backwards, double& startpts) override;
   virtual DemuxPacket* DemuxRead() override;
+  virtual void DemuxSetSpeed(int speed) override;
   virtual void GetCapabilities(INPUTSTREAM_CAPABILITIES& caps) override;
 
   virtual int64_t SeekStream(int64_t position, int whence = SEEK_SET) override;
   virtual int64_t LengthStream() override;
   virtual bool GetTimes(INPUTSTREAM_TIMES& times) override;
-
-  virtual bool CanPauseStream() override;
-  virtual bool CanSeekStream() override;
 
 protected:
   void UpdateCurrentPTS() override;
@@ -60,4 +58,6 @@ protected:
 
   bool m_bIsOpening;
   double m_seekOffset;
+  double m_pauseStartTime;
+  double m_currentDemuxTime;
 };

--- a/src/stream/FFmpegStream.cpp
+++ b/src/stream/FFmpegStream.cpp
@@ -522,19 +522,6 @@ bool FFmpegStream::PosTime(int ms)
   return SeekTime(static_cast<double>(ms) * 0.001f);
 }
 
-/* CHATPER */
-
-
-bool FFmpegStream::CanPauseStream()
-{
-  return false;
-}
-
-bool FFmpegStream::CanSeekStream()
-{
-  return false;
-}
-
 int FFmpegStream::ReadStream(uint8_t* buf, unsigned int size)
 {
   return -1;
@@ -553,12 +540,6 @@ int64_t FFmpegStream::PositionStream()
 int64_t FFmpegStream::LengthStream()
 {
   return -1;
-}
-
-void FFmpegStream::PauseStream(double time)
-{
-  m_paused = !m_paused;
-  //RTMP_Pause(m_session, m_paused);
 }
 
 bool FFmpegStream::IsRealTimeStream()

--- a/src/stream/FFmpegStream.h
+++ b/src/stream/FFmpegStream.h
@@ -76,13 +76,10 @@ public:
   virtual int64_t GetChapterPos(int ch) override;
   virtual bool SeekChapter(int ch) override;
 
-  virtual bool CanPauseStream() override;
-  virtual bool CanSeekStream() override;
   virtual int ReadStream(uint8_t* buffer, unsigned int bufferSize) override;
   virtual int64_t SeekStream(int64_t position, int whence = SEEK_SET) override;
   virtual int64_t PositionStream() override;
   virtual int64_t LengthStream() override;
-  virtual void PauseStream(double time) override;
   virtual bool IsRealTimeStream() override; // { return true; }
 
   void Dispose();
@@ -94,6 +91,7 @@ public:
 protected:
   virtual std::string GetStreamCodecName(int iStreamId);
   virtual void UpdateCurrentPTS();
+  bool IsPaused() { return m_speed == DVD_PLAYSPEED_PAUSE; }
 
   int64_t m_demuxerId;
   CCriticalSection m_critSection;


### PR DESCRIPTION
v1.8.0
- Added: Support live URL in addition to catchup URL
- Added: Support resuming from pause and Inputstream API v2.1.0

Kodi PR for API change: https://github.com/xbmc/xbmc/pull/17620