### PR TITLE
Suppress verbose logging on libxml2 on osx that causes travis builds to fail

### DIFF
--- a/depends/common/libxml2/CMakeLists.txt
+++ b/depends/common/libxml2/CMakeLists.txt
@@ -4,6 +4,10 @@ cmake_minimum_required(VERSION 3.5)
 
 list(APPEND CMAKE_MODULE_PATH ${PROJECT_SOURCE_DIR})
 
+if (APPLE)
+  # For some reason libxml2 requires this flag or it will create an insane amout of log output on compile
+  list(APPEND libxml2_conf CFLAGS=-Wno-nullability-completeness)
+endif()
 list(APPEND libxml2_conf CPPFLAGS=-I${CMAKE_INSTALL_PREFIX}/include)
 list(APPEND libxml2_conf LDFLAGS=-L${CMAKE_INSTALL_PREFIX}/lib)
 

--- a/inputstream.ffmpegdirect/addon.xml.in
+++ b/inputstream.ffmpegdirect/addon.xml.in
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <addon
   id="inputstream.ffmpegdirect"
-  version="1.8.0"
+  version="1.8.1"
   name="Inputstream FFmpeg Direct"
   provider-name="phunkyfish">
   <requires>@ADDON_DEPENDS@</requires>
@@ -23,6 +23,9 @@
       <fanart>fanart.jpg</fanart>
     </assets>
     <news>
+v1.8.1
+- Fixed: Suppress verbose logging on libxml2 on osx that causes travis builds to fail
+
 v1.8.0
 - Added: Support live URL in addition to catchup URL
 - Added: Support resuming from pause and to catchup stream

--- a/inputstream.ffmpegdirect/changelog.txt
+++ b/inputstream.ffmpegdirect/changelog.txt
@@ -1,3 +1,6 @@
+v1.8.1
+- Fixed: Suppress verbose logging on libxml2 on osx that causes travis builds to fail
+
 v1.8.0
 - Added: Support live URL in addition to catchup URL
 - Added: Support resuming from pause and to catchup stream


### PR DESCRIPTION
v1.8.1
- Fixed: Suppress verbose logging on libxml2 on osx that causes travis builds to fail