### PR TITLE
Proxy support and Inputstream API 2.2.0

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -52,6 +52,7 @@ set(CATCHUP_HEADERS src/StreamManager.h
                     src/stream/threads/Timer.h
                     src/stream/threads/TimeUtils.h
                     src/stream/threads/platform/ThreadImpl.h
+                    src/utils/HttpProxy.h
                     src/utils/Log.h
                     src/stream/url/URL.h
                     src/stream/url/UrlOptions.h

--- a/README.md
+++ b/README.md
@@ -49,6 +49,17 @@ Note that the steps in the following section need to be performed before the add
 
 If you would prefer to run the rebuild steps manually instead of using the above helper script check the appendix [here](#manual-steps-to-rebuild-the-addon-on-macosx)
 
+## Settings
+
+### HTTP Proxy
+Settings for configuring the HTTP Proxy
+
+* **Use HTTP proxy**: Whether or not a proxy should be used.
+* **Server**: Configure the proxy server address.
+* **Port**: Configure the proxy server port.
+* **Username**: Configure the proxy server username.
+* **Password**: Configure the proxy server password.
+
 ## Using the addon
 
 The addon can be accessed like any other inputstream in Kodi. The following example will show how to manually choose this addon for playback when using IPTV Simple Client with the following entry in the M3U file (Note that the IPTV Simple Client will in fact automatcially detect a catchup stream and use the addon based on configured settings).

--- a/inputstream.ffmpegdirect/addon.xml.in
+++ b/inputstream.ffmpegdirect/addon.xml.in
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <addon
   id="inputstream.ffmpegdirect"
-  version="1.8.2"
+  version="1.9.0"
   name="Inputstream FFmpeg Direct"
   provider-name="phunkyfish">
   <requires>@ADDON_DEPENDS@</requires>
@@ -23,6 +23,11 @@
       <fanart>fanart.jpg</fanart>
     </assets>
     <news>
+v1.9.0
+- Added: HTTP Proxy support
+- Update: Remove PauseStream for Inputstream API 2.2.0
+- Fixed: fix changelog.in for debian packaging
+
 v1.8.2
 - Fixed: Ubuntu packaging
 - Added: Updated RTP patch

--- a/inputstream.ffmpegdirect/changelog.txt
+++ b/inputstream.ffmpegdirect/changelog.txt
@@ -1,3 +1,8 @@
+v1.9.0
+- Added: HTTP Proxy support
+- Update: Remove PauseStream for Inputstream API 2.2.0
+- Fixed: fix changelog.in for debian packaging
+
 v1.8.2
 - Fixed: Ubuntu packaging
 - Added: Updated RTP patch

--- a/inputstream.ffmpegdirect/resources/language/resource.language.en_gb/strings.po
+++ b/inputstream.ffmpegdirect/resources/language/resource.language.en_gb/strings.po
@@ -1,0 +1,84 @@
+# Kodi Media Center language file
+# Addon Name: Inputstream.ffmpegdirect
+# Addon id: inputstream.ffmpegdirect
+# Addon Provider: phunkyfish
+
+msgid ""
+msgstr ""
+
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Language: en\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+
+#. settings labels
+
+#. label-category: httpProxy
+#. label-group: HTTP proxy - httpProxt
+msgctxt "#30000"
+msgid "HTTP proxy"
+msgstr ""
+
+#. label: HTTP proxy - useHttpProxy
+msgctxt "#30001"
+msgid "Use HTTP proxy"
+msgstr ""
+
+#. label-option: HTTP proxy - httpProxyHost
+msgctxt "#30002"
+msgid "Server"
+msgstr ""
+
+#. label-option: HTTP proxy - httpProxyPort
+msgctxt "#30003"
+msgid "Port"
+msgstr ""
+
+#. label-option: HTTP proxy - httpProxyUser
+msgctxt "#30004"
+msgid "Username"
+msgstr ""
+
+#. label-option: HTTP proxy - httpProxyPassword
+msgctxt "#30005"
+msgid "Password"
+msgstr ""
+
+#empty strings from id 30007 to 30600
+
+#. ############
+#. help info #
+#. ############
+
+#. help info - HTTP Proxy
+
+#. help-category: httpProxy
+msgctxt "#30600"
+msgid "This categoty contains the settings for how the proxy is configured."
+msgstr ""
+
+#. help: HTTP Proxy - useHttpProxy
+msgctxt "#30601"
+msgid "Whether or not a proxy should be used."
+msgstr ""
+
+#. help: HTTP Proxy - httpProxyHost
+msgctxt "#30602"
+msgid "Configure the proxy server address."
+msgstr ""
+
+#. help: HTTP Proxy - httpProxyPort
+msgctxt "#30603"
+msgid "Configure the proxy server port."
+msgstr ""
+
+#. help: HTTP Proxy - httpProxyUser
+msgctxt "#30604"
+msgid "Configure the proxy server username."
+msgstr ""
+
+#. help: HTTP Proxy - httpProxyPassword
+msgctxt "#30605"
+msgid "Configure the proxy server password."
+msgstr ""

--- a/inputstream.ffmpegdirect/resources/settings.xml
+++ b/inputstream.ffmpegdirect/resources/settings.xml
@@ -1,0 +1,62 @@
+<?xml version="1.0" encoding="utf-8" standalone="yes"?>
+<settings version="1">
+  <section id="inputstream.ffmpegdirect">
+    <category id="httpProxy" label="30000" help="30600">
+      <group id="1" label="30000">
+        <setting id="useHttpProxy" type="boolean" label="30001" help="30601">
+          <level>1</level>
+          <default>false</default>
+          <control type="toggle" />
+        </setting>
+        <setting id="httpProxyHost" type="string" parent="useHttpProxy" label="30002" help="30602">
+          <level>1</level>
+          <default></default>
+          <constraints>
+            <allowempty>true</allowempty>
+          </constraints>
+          <dependencies>
+            <dependency type="enable" setting="useHttpProxy">true</dependency>
+          </dependencies>
+          <control type="edit" format="string" />
+        </setting>
+        <setting id="httpProxyPort" type="integer" parent="useHttpProxy" label="30003" help="30603">
+          <level>1</level>
+          <default>8080</default>
+          <constraints>
+            <minimum>1</minimum>
+            <step>1</step>
+            <maximum>65535</maximum>
+          </constraints>
+          <dependencies>
+            <dependency type="enable" setting="useHttpProxy">true</dependency>
+          </dependencies>
+          <control type="edit" format="integer" />
+        </setting>
+        <setting id="httpProxyUser" type="string" parent="useHttpProxy" label="30004" help="30604">
+          <level>1</level>
+          <default></default>
+          <constraints>
+            <allowempty>true</allowempty>
+          </constraints>
+          <dependencies>
+            <dependency type="enable" setting="useHttpProxy">true</dependency>
+          </dependencies>
+          <control type="edit" format="string" />
+        </setting>
+        <setting id="httpProxyPassword" type="string" parent="useHttpProxy" label="30005" help="30605">
+          <level>1</level>
+          <default></default>
+          <constraints>
+            <allowempty>true</allowempty>
+          </constraints>
+          <dependencies>
+            <dependency type="enable" setting="useHttpProxy">true</dependency>
+          </dependencies>
+          <control type="edit" format="string">
+            <hidden>true</hidden>
+          </control>
+        </setting>        
+      </group>
+    </category>
+  </section>
+</settings>

--- a/src/StreamManager.cpp
+++ b/src/StreamManager.cpp
@@ -281,11 +281,6 @@ int64_t CInputStreamLibavformat::LengthStream()
   return m_stream->LengthStream();
 }
 
-void CInputStreamLibavformat::PauseStream(double time)
-{
-  // Unused when inputsream has it's own demuxer
-}
-
 bool CInputStreamLibavformat::IsRealTimeStream()
 {
   return m_stream->IsRealTimeStream();

--- a/src/StreamManager.h
+++ b/src/StreamManager.h
@@ -79,7 +79,6 @@ public:
   virtual int64_t SeekStream(int64_t position, int whence = SEEK_SET) override;
   virtual int64_t PositionStream() override;
   virtual int64_t LengthStream() override;
-  virtual void PauseStream(double time) override;
   virtual bool IsRealTimeStream() override; // { return true; }
 
   DemuxPacket* AllocateDemuxPacketFromInputStreamAPI(int dataSize) override;

--- a/src/stream/FFmpegCatchupStream.cpp
+++ b/src/stream/FFmpegCatchupStream.cpp
@@ -11,6 +11,8 @@
 #include "threads/SingleLock.h"
 #include "../utils/Log.h"
 
+using namespace ffmpegdirect::utils;
+
 #ifdef TARGET_POSIX
 #include "platform/posix/XTimeUtils.h"
 #endif
@@ -41,6 +43,7 @@ extern "C" {
 ***********************************************************/
 
 FFmpegCatchupStream::FFmpegCatchupStream(IManageDemuxPacket* demuxPacketManager,
+                                         const HttpProxy& httpProxy,
                                          std::string& defaultUrl,
                                          bool playbackAsLive,
                                          time_t programmeStartTime,
@@ -53,7 +56,7 @@ FFmpegCatchupStream::FFmpegCatchupStream(IManageDemuxPacket* demuxPacketManager,
                                          int timezoneShift,
                                          int defaultProgrammeDuration,
                                          std::string& programmeCatchupId)
-  : FFmpegStream(demuxPacketManager), m_bIsOpening(false), m_seekOffset(0),
+  : FFmpegStream(demuxPacketManager, httpProxy), m_bIsOpening(false), m_seekOffset(0),
     m_defaultUrl(defaultUrl), m_playbackAsLive(playbackAsLive),
     m_programmeStartTime(programmeStartTime), m_programmeEndTime(programmeEndTime),
     m_catchupUrlFormatString(catchupUrlFormatString),

--- a/src/stream/FFmpegCatchupStream.h
+++ b/src/stream/FFmpegCatchupStream.h
@@ -9,11 +9,13 @@
 #pragma once
 
 #include "FFmpegStream.h"
+#include "../utils/HttpProxy.h"
 
 class FFmpegCatchupStream : public FFmpegStream
 {
 public:
   FFmpegCatchupStream(IManageDemuxPacket* demuxPacketManager,
+                      const ffmpegdirect::utils::HttpProxy& httpProxy,
                       std::string& defaultUrl,
                       bool playbackAsLive,
                       time_t programmeStartTime,

--- a/src/stream/FFmpegStream.cpp
+++ b/src/stream/FFmpegStream.cpp
@@ -1209,7 +1209,7 @@ bool FFmpegStream::SeekTime(double time, bool backwards, double* startpts)
 
   if (m_checkvideo)
   {
-    XbmcThreads::EndTime timer(1000);
+    FFmpegDirectThreads::EndTime timer(1000);
 
     while (!IsVideoReady())
     {

--- a/src/stream/FFmpegStream.cpp
+++ b/src/stream/FFmpegStream.cpp
@@ -25,6 +25,8 @@
 
 // #include <kodi/addon-instance/Inputstream.h>
 
+using namespace ffmpegdirect::utils;
+
 #include <chrono>
 #include <ctime>
 
@@ -79,8 +81,9 @@ static int interrupt_cb(void* ctx)
   return 0;
 }
 
-FFmpegStream::FFmpegStream(IManageDemuxPacket* demuxPacketManager)
+FFmpegStream::FFmpegStream(IManageDemuxPacket* demuxPacketManager, const HttpProxy& httpProxy)
   : BaseStream(demuxPacketManager),
+    m_httpProxy(httpProxy),
 //    m_session(nullptr),
     m_paused(false)
 {
@@ -1973,31 +1976,84 @@ AVDictionary* FFmpegStream::GetFFMpegOptionsFromInput()
     }
   }
 
-  // if (input)
-  // {
-  //   const std::string host = input->GetProxyHost();
-  //   if (!host.empty() && input->GetProxyType() == "http")
+  const std::string host = m_httpProxy.GetProxyHost();
+  if (!host.empty())
+  {
+    std::ostringstream urlStream;
+
+    const uint16_t port = m_httpProxy.GetProxyPort();
+    const std::string user = m_httpProxy.GetProxyUser();
+    const std::string password = m_httpProxy.GetProxyPassword();
+
+    urlStream << "http://";
+
+    if (!user.empty()) {
+      urlStream << user;
+      if (!password.empty())
+        urlStream << ":" << password;
+      urlStream << "@";
+    }
+
+    urlStream << host << ':' << port;
+
+    av_dict_set(&options, "http_proxy", urlStream.str().c_str(), 0);
+  }
+
+  //   // rtmp options
+  //   if (url.IsProtocol("rtmp")  || url.IsProtocol("rtmpt")  ||
+  //       url.IsProtocol("rtmpe") || url.IsProtocol("rtmpte") ||
+  //       url.IsProtocol("rtmps"))
   //   {
-  //     std::ostringstream urlStream;
+  //     static const std::map<std::string,std::string> optionmap =
+  //     {{{"SWFPlayer", "rtmp_swfurl"},
+  //       {"swfplayer", "rtmp_swfurl"},
+  //       {"PageURL", "rtmp_pageurl"},
+  //       {"pageurl", "rtmp_pageurl"},
+  //       {"PlayPath", "rtmp_playpath"},
+  //       {"playpath", "rtmp_playpath"},
+  //       {"TcUrl",    "rtmp_tcurl"},
+  //       {"tcurl",    "rtmp_tcurl"},
+  //       {"IsLive",   "rtmp_live"},
+  //       {"islive",   "rtmp_live"},
+  //       {"swfurl",   "rtmp_swfurl"},
+  //       {"swfvfy",   "rtmp_swfverify"},
+  //     }};
 
-  //     const uint16_t port = input->GetProxyPort();
-  //     const std::string user = input->GetProxyUser();
-  //     const std::string password = input->GetProxyPassword();
-
-  //     urlStream << "http://";
-
-  //     if (!user.empty()) {
-  //       urlStream << user;
-  //       if (!password.empty())
-  //         urlStream << ":" << password;
-  //       urlStream << "@";
+  //     for (const auto& it : optionmap)
+  //     {
+  //       if (input->GetItem().HasProperty(it.first))
+  //       {
+  //         av_dict_set(&options, it.second.c_str(),
+  //                     input->GetItem().GetProperty(it.first).asString().c_str(),0);
+  //       }
   //     }
 
-  //     urlStream << host << ':' << port;
-
-  //     av_dict_set(&options, "http_proxy", urlStream.str().c_str(), 0);
+  //     CURL tmpUrl = url;
+  //     std::vector<std::string> opts = StringUtils::Split(tmpUrl.Get(), " ");
+  //     if (opts.size() > 1) // inline rtmp options
+  //     {
+  //       std::string swfurl;
+  //       bool swfvfy=false;
+  //       for (size_t i = 1; i < opts.size(); ++i)
+  //       {
+  //         std::vector<std::string> value = StringUtils::Split(opts[i], "=", 2);
+  //         StringUtils::ToLower(value[0]);
+  //         auto it = optionmap.find(value[0]);
+  //         if (it != optionmap.end())
+  //         {
+  //           if (value[0] == "swfurl" || value[0] == "SWFPlayer")
+  //             swfurl = value[1];
+  //           if (value[0] == "swfvfy" && (value[1] == "true" || value[1] == "1"))
+  //             swfvfy = true;
+  //           else
+  //             av_dict_set(&options, it->second.c_str(), value[1].c_str(), 0);
+  //         }
+  //         if (swfvfy)
+  //           av_dict_set(&options, "rtmp_swfverify", swfurl.c_str(), 0);
+  //       }
+  //       tmpUrl = CURL(opts.front());
+  //     }
   //   }
-  // }
 
   return options;
 }

--- a/src/stream/FFmpegStream.h
+++ b/src/stream/FFmpegStream.h
@@ -148,7 +148,7 @@ private:
   unsigned int m_initialProgramNumber;
   int m_seekStream;
 
-  XbmcThreads::EndTime  m_timeout;
+  FFmpegDirectThreads::EndTime  m_timeout;
 
   // Due to limitations of ffmpeg, we only can detect a program change
   // with a packet. This struct saves the packet for the next read and

--- a/src/stream/FFmpegStream.h
+++ b/src/stream/FFmpegStream.h
@@ -11,6 +11,7 @@
 #include "threads/CriticalSection.h"
 #include "threads/SystemClock.h"
 
+#include "../utils/HttpProxy.h"
 #include "BaseStream.h"
 #include "DemuxStream.h"
 
@@ -46,7 +47,7 @@ class FFmpegStream
   : public BaseStream
 {
 public:
-  FFmpegStream(IManageDemuxPacket* demuxPacketManager);
+  FFmpegStream(IManageDemuxPacket* demuxPacketManager, const ffmpegdirect::utils::HttpProxy& httpProxy);
   ~FFmpegStream();
 
   virtual bool Open(const std::string& streamUrl, const std::string& mimeType, bool isRealTimeStream, const std::string& programProperty) override;
@@ -170,4 +171,6 @@ private:
   std::string m_programProperty;
   bool m_isRealTimeStream;
   bool m_opened;
+
+  ffmpegdirect::utils::HttpProxy m_httpProxy;
 };

--- a/src/stream/threads/Condition.h
+++ b/src/stream/threads/Condition.h
@@ -14,7 +14,7 @@
 #include <chrono>
 #include <condition_variable>
 
-namespace XbmcThreads
+namespace FFmpegDirectThreads
 {
 
   /**

--- a/src/stream/threads/CriticalSection.h
+++ b/src/stream/threads/CriticalSection.h
@@ -11,4 +11,4 @@
 #include "platform/RecursiveMutex.h"
 #include "Lockables.h"
 
-class CCriticalSection : public XbmcThreads::CountingLockable<XbmcThreads::CRecursiveMutex> {};
+class CCriticalSection : public FFmpegDirectThreads::CountingLockable<FFmpegDirectThreads::CRecursiveMutex> {};

--- a/src/stream/threads/Event.cpp
+++ b/src/stream/threads/Event.cpp
@@ -11,16 +11,16 @@
 #include <algorithm>
 #include <limits>
 
-void CEvent::addGroup(XbmcThreads::CEventGroup* group)
+void CEvent::addGroup(FFmpegDirectThreads::CEventGroup* group)
 {
   CSingleLock lock(groupListMutex);
   if (!groups)
-    groups.reset(new std::vector<XbmcThreads::CEventGroup*>);
+    groups.reset(new std::vector<FFmpegDirectThreads::CEventGroup*>);
 
   groups->push_back(group);
 }
 
-void CEvent::removeGroup(XbmcThreads::CEventGroup* group)
+void CEvent::removeGroup(FFmpegDirectThreads::CEventGroup* group)
 {
   CSingleLock lock(groupListMutex);
   if (groups)
@@ -57,7 +57,7 @@ void CEvent::Set()
   }
 }
 
-namespace XbmcThreads
+namespace FFmpegDirectThreads
 {
   /**
    * This will block until any one of the CEvents in the group are

--- a/src/stream/threads/Event.h
+++ b/src/stream/threads/Event.h
@@ -16,7 +16,7 @@
 #include <vector>
 
 // forward declare the CEventGroup
-namespace XbmcThreads
+namespace FFmpegDirectThreads
 {
   class CEventGroup;
 }
@@ -38,21 +38,21 @@ class CEvent
   unsigned int numWaits = 0;
 
   CCriticalSection groupListMutex; // lock for the groups list
-  std::unique_ptr<std::vector<XbmcThreads::CEventGroup*>> groups;
+  std::unique_ptr<std::vector<FFmpegDirectThreads::CEventGroup*>> groups;
 
   /**
    * To satisfy the TightConditionVariable requirements and allow the
    *  predicate being monitored to include both the signaled and interrupted
    *  states.
    */
-  XbmcThreads::ConditionVariable actualCv;
-  XbmcThreads::TightConditionVariable<volatile bool&> condVar;
+  FFmpegDirectThreads::ConditionVariable actualCv;
+  FFmpegDirectThreads::TightConditionVariable<volatile bool&> condVar;
   CCriticalSection mutex;
 
-  friend class XbmcThreads::CEventGroup;
+  friend class FFmpegDirectThreads::CEventGroup;
 
-  void addGroup(XbmcThreads::CEventGroup* group);
-  void removeGroup(XbmcThreads::CEventGroup* group);
+  void addGroup(FFmpegDirectThreads::CEventGroup* group);
+  void removeGroup(FFmpegDirectThreads::CEventGroup* group);
 
   // helper for the two wait methods
   inline bool prepReturn() { bool ret = signaled; if (!manualReset && numWaits == 0) signaled = false; return ret; }
@@ -94,7 +94,7 @@ public:
 
 };
 
-namespace XbmcThreads
+namespace FFmpegDirectThreads
 {
   /**
    * CEventGroup is a means of grouping CEvents to wait on them together.
@@ -105,8 +105,8 @@ namespace XbmcThreads
   {
     std::vector<CEvent*> events;
     CEvent* signaled{};
-    XbmcThreads::ConditionVariable actualCv;
-    XbmcThreads::TightConditionVariable<CEvent*&> condVar{actualCv, signaled};
+    FFmpegDirectThreads::ConditionVariable actualCv;
+    FFmpegDirectThreads::TightConditionVariable<CEvent*&> condVar{actualCv, signaled};
     CCriticalSection mutex;
 
     unsigned int numWaits{0};

--- a/src/stream/threads/Helpers.h
+++ b/src/stream/threads/Helpers.h
@@ -8,7 +8,7 @@
 
 #pragma once
 
-namespace XbmcThreads
+namespace FFmpegDirectThreads
 {
   /**
    * This will create a new predicate from an old predicate P with

--- a/src/stream/threads/Lockables.h
+++ b/src/stream/threads/Lockables.h
@@ -8,7 +8,7 @@
 
 #pragma once
 
-namespace XbmcThreads
+namespace FFmpegDirectThreads
 {
 
   /**

--- a/src/stream/threads/SharedSection.h
+++ b/src/stream/threads/SharedSection.h
@@ -18,13 +18,13 @@
 class CSharedSection
 {
   CCriticalSection sec;
-  XbmcThreads::ConditionVariable actualCv;
-  XbmcThreads::TightConditionVariable<XbmcThreads::InversePredicate<unsigned int&> > cond;
+  FFmpegDirectThreads::ConditionVariable actualCv;
+  FFmpegDirectThreads::TightConditionVariable<FFmpegDirectThreads::InversePredicate<unsigned int&> > cond;
 
   unsigned int sharedCount = 0;
 
 public:
-  inline CSharedSection() : cond(actualCv,XbmcThreads::InversePredicate<unsigned int&>(sharedCount)) {}
+  inline CSharedSection() : cond(actualCv,FFmpegDirectThreads::InversePredicate<unsigned int&>(sharedCount)) {}
 
   inline void lock() { CSingleLock l(sec); while (sharedCount) cond.wait(l); sec.lock(); }
   inline bool try_lock() { return (sec.try_lock() ? ((sharedCount == 0) ? true : (sec.unlock(), false)) : false); }
@@ -35,20 +35,20 @@ public:
   inline void unlock_shared() { CSingleLock l(sec); sharedCount--; if (!sharedCount) { cond.notifyAll(); } }
 };
 
-class CSharedLock : public XbmcThreads::SharedLock<CSharedSection>
+class CSharedLock : public FFmpegDirectThreads::SharedLock<CSharedSection>
 {
 public:
-  inline explicit CSharedLock(CSharedSection& cs) : XbmcThreads::SharedLock<CSharedSection>(cs) {}
+  inline explicit CSharedLock(CSharedSection& cs) : FFmpegDirectThreads::SharedLock<CSharedSection>(cs) {}
 
   inline bool IsOwner() const { return owns_lock(); }
   inline void Enter() { lock(); }
   inline void Leave() { unlock(); }
 };
 
-class CExclusiveLock : public XbmcThreads::UniqueLock<CSharedSection>
+class CExclusiveLock : public FFmpegDirectThreads::UniqueLock<CSharedSection>
 {
 public:
-  inline explicit CExclusiveLock(CSharedSection& cs) : XbmcThreads::UniqueLock<CSharedSection>(cs) {}
+  inline explicit CExclusiveLock(CSharedSection& cs) : FFmpegDirectThreads::UniqueLock<CSharedSection>(cs) {}
 
   inline bool IsOwner() const { return owns_lock(); }
   inline void Leave() { unlock(); }

--- a/src/stream/threads/SingleLock.h
+++ b/src/stream/threads/SingleLock.h
@@ -19,15 +19,15 @@
  * This implements a "guard" pattern for a CCriticalSection that
  *  borrows most of it's functionality from boost's unique_lock.
  */
-class CSingleLock :  public XbmcThreads::UniqueLock<CCriticalSection>
+class CSingleLock :  public FFmpegDirectThreads::UniqueLock<CCriticalSection>
 {
 public:
-  inline explicit CSingleLock(CCriticalSection& cs) : XbmcThreads::UniqueLock<CCriticalSection>(cs) {}
+  inline explicit CSingleLock(CCriticalSection& cs) : FFmpegDirectThreads::UniqueLock<CCriticalSection>(cs) {}
 
   inline void Leave() { unlock(); }
   inline void Enter() { lock(); }
 protected:
-  inline CSingleLock(CCriticalSection& cs, bool dicrim) : XbmcThreads::UniqueLock<CCriticalSection>(cs,true) {}
+  inline CSingleLock(CCriticalSection& cs, bool dicrim) : FFmpegDirectThreads::UniqueLock<CCriticalSection>(cs,true) {}
 };
 
 

--- a/src/stream/threads/SystemClock.cpp
+++ b/src/stream/threads/SystemClock.cpp
@@ -12,7 +12,7 @@
 
 #include <stdint.h>
 
-namespace XbmcThreads
+namespace FFmpegDirectThreads
 {
   unsigned int SystemClockMillis()
   {

--- a/src/stream/threads/SystemClock.h
+++ b/src/stream/threads/SystemClock.h
@@ -12,7 +12,7 @@
 #include <limits>
 #include <thread>
 
-namespace XbmcThreads
+namespace FFmpegDirectThreads
 {
   /**
    * This function returns the system clock's number of milliseconds but with

--- a/src/stream/threads/Thread.cpp
+++ b/src/stream/threads/Thread.cpp
@@ -74,7 +74,7 @@ void CThread::Create(bool bAutoDelete)
       exit(1);
     }
   }
-  m_iLastTime = XbmcThreads::SystemClockMillis() * 10000ULL;
+  m_iLastTime = FFmpegDirectThreads::SystemClockMillis() * 10000ULL;
   m_iLastUsage = 0;
   m_fLastUsage = 0.0f;
   m_bAutoDelete = bAutoDelete;
@@ -299,7 +299,7 @@ void CThread::Action()
 
 float CThread::GetRelativeUsage()
 {
-  unsigned int iTime = XbmcThreads::SystemClockMillis();
+  unsigned int iTime = FFmpegDirectThreads::SystemClockMillis();
   iTime *= 10000; // convert into 100ns tics
 
   // only update every 1 second

--- a/src/stream/threads/Thread.h
+++ b/src/stream/threads/Thread.h
@@ -86,7 +86,7 @@ protected:
    */
   inline WaitResponse AbortableWait(CEvent& event, int timeoutMillis = -1 /* indicates wait forever*/)
   {
-    XbmcThreads::CEventGroup group{&event, &m_StopEvent};
+    FFmpegDirectThreads::CEventGroup group{&event, &m_StopEvent};
     CEvent* result = timeoutMillis < 0 ? group.wait() : group.wait(timeoutMillis);
     return  result == &event ? WAIT_SIGNALED :
       (result == NULL ? WAIT_TIMEDOUT : WAIT_INTERRUPTED);

--- a/src/stream/threads/Timer.cpp
+++ b/src/stream/threads/Timer.cpp
@@ -56,7 +56,7 @@ bool CTimer::Stop(bool wait /* = false */)
 void CTimer::RestartAsync(uint32_t timeout)
 {
   m_timeout = timeout;
-  m_endTime = XbmcThreads::SystemClockMillis() + timeout;
+  m_endTime = FFmpegDirectThreads::SystemClockMillis() + timeout;
   m_eventTimeout.Set();
 }
 
@@ -79,20 +79,20 @@ float CTimer::GetElapsedMilliseconds() const
   if (!IsRunning())
     return 0.0f;
 
-  return (float)(XbmcThreads::SystemClockMillis() - (m_endTime - m_timeout));
+  return (float)(FFmpegDirectThreads::SystemClockMillis() - (m_endTime - m_timeout));
 }
 
 void CTimer::Process()
 {
   while (!m_bStop)
   {
-    uint32_t currentTime = XbmcThreads::SystemClockMillis();
+    uint32_t currentTime = FFmpegDirectThreads::SystemClockMillis();
     m_endTime = currentTime + m_timeout;
 
     // wait the necessary time
     if (!m_eventTimeout.WaitMSec(m_endTime - currentTime))
     {
-      currentTime = XbmcThreads::SystemClockMillis();
+      currentTime = FFmpegDirectThreads::SystemClockMillis();
       if (m_endTime <= currentTime)
       {
         // execute OnTimeout() callback

--- a/src/stream/threads/platform/RecursiveMutex.h
+++ b/src/stream/threads/platform/RecursiveMutex.h
@@ -12,7 +12,7 @@
 
 #if (defined TARGET_POSIX)
 #include <pthread.h>
-namespace XbmcThreads
+namespace FFmpegDirectThreads
 {
   class CRecursiveMutex
   {
@@ -43,7 +43,7 @@ namespace XbmcThreads
   };
 }
 #elif (defined TARGET_WINDOWS)
-namespace XbmcThreads
+namespace FFmpegDirectThreads
 {
   typedef std::recursive_mutex CRecursiveMutex;
 }

--- a/src/stream/threads/platform/pthreads/ThreadImpl.cpp
+++ b/src/stream/threads/platform/pthreads/ThreadImpl.cpp
@@ -22,7 +22,7 @@
 #include <signal.h>
 #include "../../../../utils/Log.h"
 
-namespace XbmcThreads
+namespace FFmpegDirectThreads
 {
 // ==========================================================
 static pthread_mutexattr_t recursiveAttr;

--- a/src/stream/threads/test/TestEvent.cpp
+++ b/src/stream/threads/test/TestEvent.cpp
@@ -13,7 +13,7 @@
 #include <memory>
 #include <stdio.h>
 
-using namespace XbmcThreads;
+using namespace FFmpegDirectThreads;
 
 //=============================================================================
 // Helper classes

--- a/src/stream/threads/test/TestHelpers.h
+++ b/src/stream/threads/test/TestHelpers.h
@@ -14,7 +14,7 @@
 
 #define MILLIS(x) x
 
-inline static void SleepMillis(unsigned int millis) { XbmcThreads::ThreadSleep(millis); }
+inline static void SleepMillis(unsigned int millis) { FFmpegDirectThreads::ThreadSleep(millis); }
 
 template<class E> inline static bool waitForWaiters(E& event, int numWaiters, int milliseconds)
 {

--- a/src/utils/HttpProxy.h
+++ b/src/utils/HttpProxy.h
@@ -1,0 +1,43 @@
+/*
+ *  Copyright (C) 2005-2020 Team Kodi
+ *  https://kodi.tv
+ *
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *  See LICENSE.md for more information.
+ */
+
+#pragma once
+
+#include <string>
+
+namespace ffmpegdirect
+{
+  namespace utils
+  {
+    class HttpProxy
+    {
+    public:
+      HttpProxy() {};
+      HttpProxy(const std::string& host, uint16_t port, const std::string& user, const std::string& password)
+        : m_host(host), m_port(port), m_user(user), m_password(password) {};
+
+      const std::string& GetProxyHost() const { return m_host; }
+      void SetProxyHost(const std::string& value) { m_host = value; }
+
+      uint16_t GetProxyPort() const { return m_port; }
+      void SetProxyPort(uint16_t value) { m_port = value; }
+
+      const std::string& GetProxyUser() const { return m_user; }
+      void SetProxyUser(const std::string& value) { m_user = value; }
+
+      const std::string& GetProxyPassword() const { return m_password; }
+      void SetProxyPassword(const std::string& value) { m_password = value; }
+
+    private:
+      std::string m_host;
+      uint16_t m_port;
+      std::string m_user;
+      std::string m_password;
+    };
+  } //namespace utils
+} //namespace ffmpegdirect


### PR DESCRIPTION
v1.9.0
- Added: HTTP Proxy support
- Update: Remove PauseStream for Inputstream API 2.2.0
- Fixed: fix changelog.in for debian packaging

Part of: https://github.com/xbmc/xbmc/pull/17633

Do not merge yet