### PR TITLE
VOD seek and Timeshift for live streams

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -29,6 +29,9 @@ set(CATCHUP_SOURCES src/StreamManager.cpp
                     src/stream/threads/Timer.cpp
                     src/stream/threads/TimeUtils.cpp
                     src/stream/threads/SystemClock.cpp
+                    src/stream/TimeshiftBuffer.cpp
+                    src/stream/TimeshiftSegment.cpp
+                    src/stream/TimeshiftStream.cpp
                     src/stream/url/URL.cpp
                     src/stream/url/UrlOptions.cpp
                     src/stream/url/Variant.cpp
@@ -57,6 +60,9 @@ set(CATCHUP_HEADERS src/StreamManager.h
                     src/stream/threads/Timer.h
                     src/stream/threads/TimeUtils.h
                     src/stream/threads/platform/ThreadImpl.h
+                    src/stream/TimeshiftBuffer.h
+                    src/stream/TimeshiftSegment.h
+                    src/stream/TimeshiftStream.h
                     src/utils/HttpProxy.h
                     src/utils/FilenameUtils.h
                     src/utils/Log.h

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -60,6 +60,7 @@ set(CATCHUP_HEADERS src/StreamManager.h
                     src/utils/HttpProxy.h
                     src/utils/FilenameUtils.h
                     src/utils/Log.h
+                    src/utils/Properties.h
                     src/stream/url/URL.h
                     src/stream/url/UrlOptions.h
                     src/stream/url/Variant.h)

--- a/README.md
+++ b/README.md
@@ -65,6 +65,11 @@ This category contains the settings for timeshift. Timeshifting allows you to pa
 
 * **Timeshift buffer path**: The path used to store the timeshift buffer. The default is the `addon_data/inputstream.ffmpegdirect/timeshift` folder in userdata. Note that this folder will be cleared of timeshift files on Kodi startup. Only relevant when `inputstream.ffmpegdirect.stream_mode=timeshift" property is passed to the addon.
 
+### Advanced
+This category contains the advanced settings for the addon.
+
+* **Allow FFmpeg logging**: If enabled the addon will log any FFmpeg logging to the Kodi log.
+
 ## Using the addon
 
 The addon can be accessed like any other inputstream in Kodi. The following example will show how to manually choose this addon for playback when using IPTV Simple Client with the following entry in the M3U file (Note that the IPTV Simple Client will in fact automatcially detect a catchup stream and use the addon based on configured settings).

--- a/README.md
+++ b/README.md
@@ -60,6 +60,11 @@ Contains the settings for how the proxy is configured when opening with FFmpeg. 
 * **Username**: Configure the proxy server username.
 * **Password**: Configure the proxy server password.
 
+### Timeshift
+This category contains the settings for timeshift. Timeshifting allows you to pause live TV as well as move back and forward from your current position similar to playing back a recording.
+
+* **Timeshift buffer path**: The path used to store the timeshift buffer. The default is the `addon_data/inputstream.ffmpegdirect/timeshift` folder in userdata. Note that this folder will be cleared of timeshift files on Kodi startup. Only relevant when `inputstream.ffmpegdirect.stream_mode=timeshift" property is passed to the addon.
+
 ## Using the addon
 
 The addon can be accessed like any other inputstream in Kodi. The following example will show how to manually choose this addon for playback when using IPTV Simple Client with the following entry in the M3U file (Note that the IPTV Simple Client will in fact automatcially detect a catchup stream and use the addon based on configured settings).
@@ -80,7 +85,19 @@ Note that the appropriate mime type should always be set. Here are the some comm
 
 The field `program_number` can be used to indicate the Program ID to use for TS streams.
 
-If enabling archive/catchup support there are a number of other properties that needs to be set as shown in this example.
+If enabling **timeshift** support for live streams here is an example set of properties.
+
+```
+#KODIPROP:inputstream=inputstream.ffmpegdirect
+#KODIPROP:mimetype=application/x-mpegURL
+#KODIPROP:inputstream.ffmpegdirect.is_realtime_stream=true
+#KODIPROP:inputstream.ffmpegdirect.stream_mode=timeshift
+#KODIPROP:inputstream.ffmpegdirect.manifest_type=hls
+#EXTINF:-1,MyChannel
+http://127.0.0.1:3002/mystream.m3u8
+```
+
+If enabling **archive/catchup** support there are a number of other properties that needs to be set as shown in this example.
 
 ```
 #KODIPROP:inputstream=inputstream.ffmpegdirect
@@ -103,9 +120,9 @@ If enabling archive/catchup support there are a number of other properties that 
 http://127.0.0.1:3002/mystream.m3u8
 ```
 
-- `stream_mode`: If the value `catchup` is supplied the inputstream will start in catchup mode. Any other value or if omitted will open as a regular stream.
+- `stream_mode`: If the value `timeshift` is supplied the live stream will have a local timeshift buffer. If `catchup` is supplied the inputstream will start in catchup mode. Any other value or if omitted will open as a regular stream.
 - `open_mode`: If the value `ffmpeg` is supplied the inputstream will be opened with AVFormat. If the value `curl` is supplied the inputstream will be opened with cURL. If neither value is supplied the default is to open HLS, Dash and Smooth Streaming with AVFormat and anything else as a kodi file. Note that a `mimetype` or `manifest_type` property is required to be able to tell if a stream is HLS or Dash. If using Smooth streaming only a `manifest_type` property will work as Smooth Streaming does not have a mimetype.
-- `manifest_type`: Allowed values are `hls` for HLS, `mpd` for Dash and `ism` for Smooth Streaming. 
+- `manifest_type`: Allowed values are `hls` for HLS, `mpd` for Dash and `ism` for Smooth Streaming.
 - `default_url`: The URL to use if a catchup URL cannot be generated for any reason.
 - `playback_as_live`: Should the playback be considerd as live tv, allowing skipping from one programme to the next over the entire catchup window, if so set to `true`. Otherwise set to `false` to treat all programmes as videos.
 - `programme_start_time`: The unix time in seconds of the start of the programme being streamed - optional.

--- a/inputstream.ffmpegdirect/addon.xml.in
+++ b/inputstream.ffmpegdirect/addon.xml.in
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <addon
   id="inputstream.ffmpegdirect"
-  version="1.11.0"
+  version="1.12.0"
   name="Inputstream FFmpeg Direct"
   provider-name="Ross Nicholson">
   <requires>@ADDON_DEPENDS@</requires>
@@ -24,6 +24,14 @@
       <fanart>fanart.jpg</fanart>
     </assets>
     <news>
+v1.12.0
+- Added: Support seeking for VOD streams or regular file playback
+- Fixed: Update HLS iformat name and remove hls workaround which is fixed in current FFmpeg
+- Added: Timeshift for live streams (experimental)
+- Added: Add support for Kodi user-agent and cookies when calling FFmpeg directly
+- Added: Support multiple occurrences of year, month and day in catchup format specifiers
+- Added: Add option to turn FFmpeg logging on/off
+
 v1.11.0
 - Update: inputstream API 2.3.1
 - Update: Global API 1.2.0

--- a/inputstream.ffmpegdirect/addon.xml.in
+++ b/inputstream.ffmpegdirect/addon.xml.in
@@ -12,6 +12,7 @@
     tags="true"
     listitemprops="program_number|stream_mode|open_mode|manifest_type|default_url|is_realtime_stream|playback_as_live|programme_start_time|programme_end_time|catchup_url_format_string|catchup_url_near_live_format_string|catchup_buffer_start_time|catchup_buffer_end_time|catchup_buffer_offset|catchup_terminates|catchup_granularity|timezone_shift|default_programme_duration|programme_catchup_id"
     library_@PLATFORM@="@LIBRARY_FILENAME@" />
+  <extension point="xbmc.service" library="resources/lib/runner.py"/>
   <extension point="xbmc.addon.metadata">
     <summary lang="en_GB">InputStream Client for FFmpeg streams (libavformat)</summary>
     <description lang="en_GB">InputStream Client for streams that can be opened by either FFmpeg's libavformat or Kodi's cURL. Common stream formats such as plain TS, HLS and DASH (without DRM) are supported as well as many others.&#10;    &#10;The addon also has support for Archive/Catchup services where there is a replay windows (usually in days) and can timeshift across that span.&#10;    &#10;For documenation visit: https://github.com/xbmc/inputstream.ffmpegdirect/blob/Matrix/README.md&#10;    </description>

--- a/inputstream.ffmpegdirect/changelog.txt
+++ b/inputstream.ffmpegdirect/changelog.txt
@@ -1,3 +1,11 @@
+v1.12.0
+- Added: Support seeking for VOD streams or regular file playback
+- Fixed: Update HLS iformat name and remove hls workaround which is fixed in current FFmpeg
+- Added: Timeshift for live streams (experimental)
+- Added: Add support for Kodi user-agent and cookies when calling FFmpeg directly
+- Added: Support multiple occurrences of year, month and day in catchup format specifiers
+- Added: Add option to turn FFmpeg logging on/off
+
 v1.11.0
 - Update: inputstream API 2.3.1
 - Update: Global API 1.2.0

--- a/inputstream.ffmpegdirect/resources/language/resource.language.en_gb/strings.po
+++ b/inputstream.ffmpegdirect/resources/language/resource.language.en_gb/strings.po
@@ -45,7 +45,20 @@ msgctxt "#30005"
 msgid "Password"
 msgstr ""
 
-#empty strings from id 30006 to 30599
+#empty strings from id 30006 to 30019
+
+#. label-category: timeshift
+#. label-group: Timeshift - Timeshift
+msgctxt "#30020"
+msgid "Timeshift"
+msgstr ""
+
+#. label: Timeshift - timeshiftbufferpath
+msgctxt "#30021"
+msgid "Timeshift buffer path"
+msgstr ""
+
+#empty strings from id 30022 to 30599
 
 #. ############
 #. help info #
@@ -81,4 +94,18 @@ msgstr ""
 #. help: HTTP Proxy - httpProxyPassword
 msgctxt "#30605"
 msgid "Configure the proxy server password."
+msgstr ""
+
+#empty strings from id 30606 to 30619
+
+#. help info - Timeshift
+
+#. help-category: timeshift
+msgctxt "#30620"
+msgid "This category contains the settings for timeshift. Timeshifting allows you to pause live TV as well as move back and forward from your current position similar to playing back a recording."
+msgstr ""
+
+#. help: Timeshift - timeshiftBufferPath
+msgctxt "#30621"
+msgid "The path used to store the timeshift buffer. The default is the `addon_data/inputstream.ffmpegdirect/timeshift` folder in userdata. Note that this folder will be cleared  of timeshift files on Kodi startup. Only relevant when `inputstream.ffmpegdirect.stream_mode=timeshift" property is passed to the addon."
 msgstr ""

--- a/inputstream.ffmpegdirect/resources/language/resource.language.en_gb/strings.po
+++ b/inputstream.ffmpegdirect/resources/language/resource.language.en_gb/strings.po
@@ -58,7 +58,25 @@ msgctxt "#30021"
 msgid "Timeshift buffer path"
 msgstr ""
 
-#empty strings from id 30022 to 30599
+#empty strings from id 30022 to 30039
+
+#. label-category: advanced
+msgctxt "#30040"
+msgid "Advanced"
+msgstr ""
+
+#. label-category: advanced
+#. label-group: Advanced - Logging
+msgctxt "#30041"
+msgid "Logging"
+msgstr ""
+
+#. label: Advanced - allowFFmpegLogging
+msgctxt "#30042"
+msgid "Allow FFmpeg logging"
+msgstr ""
+
+#empty strings from id 30043 to 30599
 
 #. ############
 #. help info #
@@ -108,4 +126,18 @@ msgstr ""
 #. help: Timeshift - timeshiftBufferPath
 msgctxt "#30621"
 msgid "The path used to store the timeshift buffer. The default is the `addon_data/inputstream.ffmpegdirect/timeshift` folder in userdata. Note that this folder will be cleared  of timeshift files on Kodi startup. Only relevant when `inputstream.ffmpegdirect.stream_mode=timeshift" property is passed to the addon."
+msgstr ""
+
+#empty strings from id 30622 to 30639
+
+#. help info - Advanced
+
+#. help-category: advanced
+msgctxt "#30640"
+msgid "This category contains advanced settings for the addon."
+msgstr ""
+
+#. help: Timeshift - allowFFmpegLogging
+msgctxt "#30641"
+msgid "If enabled the addon will log any FFmpeg logging to the Kodi log."
 msgstr ""

--- a/inputstream.ffmpegdirect/resources/lib/runner.py
+++ b/inputstream.ffmpegdirect/resources/lib/runner.py
@@ -1,0 +1,28 @@
+import xbmc
+import xbmcaddon
+import xbmcvfs
+
+def hidden(path):
+    return path.startswith('.') or path.startswith('_UNPACK')
+
+ADDON = xbmcaddon.Addon()
+timeshiftBufferPath = ADDON.getSetting('timeshiftBufferPath')
+
+# Add a trailing slash if we don't have as it's required to test if a directory exists
+if not timeshiftBufferPath.endswith("/"):
+    timeshiftBufferPath += "/"
+
+if xbmcvfs.exists(timeshiftBufferPath):
+    dirs, files = xbmcvfs.listdir(timeshiftBufferPath)
+    # xbmcvfs bug: sometimes return invalid utf-8 encoding. we only care about
+    # finding changed paths so it's ok to ignore here.
+
+    #dirs = [timeshiftBufferPath + _ for _ in dirs if not hidden(_)]
+    files = [timeshiftBufferPath + _ for _ in files if not hidden(_)]
+
+    # for d in dirs:
+    #     xbmcvfs.rmdir(d, true)
+    for f in files:
+        if f.endswith(".idx") or f.endswith(".seg"):
+            xbmcvfs.delete(f)
+

--- a/inputstream.ffmpegdirect/resources/settings.xml
+++ b/inputstream.ffmpegdirect/resources/settings.xml
@@ -77,5 +77,16 @@
         </setting>
       </group>
     </category>
+
+    <!-- Advanved -->
+    <category id="advanced" label="30040" help="30640">
+      <group id="1" label="30041">
+        <setting id="allowFFmpegLogging" type="boolean" label="30042" help="30641">
+          <level>2</level>
+          <default>false</default>
+          <control type="toggle" />
+        </setting>
+      </group>
+    </category>
   </section>
 </settings>

--- a/inputstream.ffmpegdirect/resources/settings.xml
+++ b/inputstream.ffmpegdirect/resources/settings.xml
@@ -1,6 +1,8 @@
 <?xml version="1.0" encoding="utf-8" standalone="yes"?>
 <settings version="1">
   <section id="inputstream.ffmpegdirect">
+
+    <!-- HTTP Proxy -->
     <category id="httpProxy" label="30000" help="30600">
       <group id="1" label="30000">
         <setting id="useHttpProxy" type="boolean" label="30001" help="30601">
@@ -55,7 +57,24 @@
           <control type="edit" format="string">
             <hidden>true</hidden>
           </control>
-        </setting>        
+        </setting>
+      </group>
+    </category>
+
+    <!-- Timeshift -->
+    <category id="timeshift" label="30020" help="30620">
+      <group id="1" label="30020">
+        <setting id="timeshiftBufferPath" type="path" label="30021" help="30621">
+          <level>0</level>
+          <default>special://userdata/addon_data/inputstream.ffmpegdirect/timeshift</default>
+          <constraints>
+            <allowempty>true</allowempty>
+            <writable>true</writable>
+          </constraints>
+          <control type="button" format="path">
+            <heading>657</heading>
+          </control>
+        </setting>
       </group>
     </category>
   </section>

--- a/src/StreamManager.cpp
+++ b/src/StreamManager.cpp
@@ -9,6 +9,7 @@
 #include "StreamManager.h"
 
 #include "stream/FFmpegCatchupStream.h"
+#include "stream/TimeshiftStream.h"
 #include "utils/HttpProxy.h"
 #include "utils/Log.h"
 
@@ -80,6 +81,8 @@ bool InputStreamFFmpegDirect::Open(INPUTSTREAM& props)
     {
       if (StringUtils::EqualsNoCase(props.m_ListItemProperties[i].m_strValue, "catchup"))
         properties.m_streamMode = StreamMode::CATCHUP;
+      else if (StringUtils::EqualsNoCase(props.m_ListItemProperties[i].m_strValue, "timeshift"))
+        properties.m_streamMode = StreamMode::TIMESHIFT;
     }
     else if (OPEN_MODE == props.m_ListItemProperties[i].m_strKey)
     {
@@ -196,6 +199,8 @@ bool InputStreamFFmpegDirect::Open(INPUTSTREAM& props)
 
   if (properties.m_streamMode == StreamMode::CATCHUP)
     m_stream = std::make_shared<FFmpegCatchupStream>(static_cast<IManageDemuxPacket*>(this), properties, httpProxy);
+  else if (properties.m_streamMode == StreamMode::TIMESHIFT)
+    m_stream = std::make_shared<TimeshiftStream>(static_cast<IManageDemuxPacket*>(this), properties, httpProxy);
   else
     m_stream = std::make_shared<FFmpegStream>(static_cast<IManageDemuxPacket*>(this), properties.m_openMode, httpProxy);
 

--- a/src/StreamManager.h
+++ b/src/StreamManager.h
@@ -94,5 +94,5 @@ private:
   int m_videoWidth;
   int m_videoHeight;
 
-  std::shared_ptr<BaseStream> m_stream;
+  std::shared_ptr<ffmpegdirect::BaseStream> m_stream;
 };

--- a/src/StreamManager.h
+++ b/src/StreamManager.h
@@ -8,9 +8,9 @@
 
 #pragma once
 
-#include "stream/FFmpegCatchupStream.h"
 #include "stream/FFmpegStream.h"
 #include "stream/IManageDemuxPacket.h"
+#include "utils/Properties.h"
 
 #include <memory>
 #include <string>
@@ -37,19 +37,12 @@ static const std::string TIMEZONE_SHIFT = "inputstream.ffmpegdirect.timezone_shi
 static const std::string DEFAULT_PROGRAMME_DURATION = "inputstream.ffmpegdirect.default_programme_duration";
 static const std::string PROGRAMME_CATCHUP_ID = "inputstream.ffmpegdirect.programme_catchup_id";
 
-enum class StreamMode
-  : int // same type as addon settings
-{
-  NONE = 0,
-  CATCHUP
-};
-
-class CInputStreamLibavformat
-  : public kodi::addon::CInstanceInputStream, IManageDemuxPacket
+class InputStreamFFmpegDirect
+  : public kodi::addon::CInstanceInputStream, ffmpegdirect::IManageDemuxPacket
 {
 public:
-  CInputStreamLibavformat(KODI_HANDLE instance, const std::string& version);
-  ~CInputStreamLibavformat();
+  InputStreamFFmpegDirect(KODI_HANDLE instance, const std::string& version);
+  ~InputStreamFFmpegDirect();
 
   virtual bool Open(INPUTSTREAM& props) override;
   virtual void Close() override;
@@ -95,26 +88,8 @@ private:
 
   std::string m_streamUrl;
   std::string m_mimeType;
-  std::string m_programProperty;
-  bool m_isRealTimeStream;
-  StreamMode m_streamMode = StreamMode::NONE;
-  OpenMode m_openMode = OpenMode::DEFAULT;
-  std::string m_manifestType;
-  std::string m_defaultUrl;
 
-  bool m_playbackAsLive = false;
-  time_t m_programmeStartTime = 0;
-  time_t m_programmeEndTime = 0;
-  std::string m_catchupUrlFormatString;
-  std::string m_catchupUrlNearLiveFormatString;
-  time_t m_catchupBufferStartTime = 0;
-  time_t m_catchupBufferEndTime = 0;
-  long long m_catchupBufferOffset = 0;
-  bool m_catchupTerminates = false;
-  int m_catchupGranularity = 1;
-  int m_timezoneShiftSecs = 0;
-  int m_defaultProgrammeDurationSecs = 4 * 60 * 60; //Four hours
-  std::string m_programmeCatchupId;
+  ffmpegdirect::Properties properties;
 
   int m_videoWidth;
   int m_videoHeight;

--- a/src/stream/BaseStream.h
+++ b/src/stream/BaseStream.h
@@ -12,12 +12,15 @@
 
 #include <kodi/addon-instance/Inputstream.h>
 
+namespace ffmpegdirect
+{
+
 class IManageDemuxPacket;
 
 class BaseStream
 {
 public:
-  BaseStream(IManageDemuxPacket* demuxPacketMamnager) : m_demuxPacketMamnager(demuxPacketMamnager) {};
+  BaseStream(IManageDemuxPacket* demuxPacketManager) : m_demuxPacketManager(demuxPacketManager) {};
 
   virtual bool Open(const std::string& streamUrl, const std::string& mimeType, bool isRealTimeStream, const std::string& programProperty) = 0;
   virtual void Close() = 0;
@@ -58,5 +61,7 @@ public:
   virtual bool IsRealTimeStream() = 0;
 
 protected:
-  IManageDemuxPacket* m_demuxPacketMamnager;
+  IManageDemuxPacket* m_demuxPacketManager;
 };
+
+} //namespace ffmpegdirect

--- a/src/stream/CurlCatchupInput.cpp
+++ b/src/stream/CurlCatchupInput.cpp
@@ -10,6 +10,8 @@
 
 #include "../utils/Log.h"
 
+using namespace ffmpegdirect;
+
 void CurlCatchupInput::Reset()
 {
   if (m_pFile)

--- a/src/stream/CurlCatchupInput.h
+++ b/src/stream/CurlCatchupInput.h
@@ -11,8 +11,13 @@
 #include "CurlInput.h"
 #include "../utils/Log.h"
 
+namespace ffmpegdirect
+{
+
 class CurlCatchupInput : public CurlInput
 {
 public:
   void Reset() override;
 };
+
+} //namespace ffmpegdirect

--- a/src/stream/CurlInput.cpp
+++ b/src/stream/CurlInput.cpp
@@ -16,6 +16,8 @@
 // #include "utils/URIUtils.h"
 #include "../utils/Log.h"
 
+using namespace ffmpegdirect;
+
 CurlInput::CurlInput()
 {
   m_pFile = nullptr;

--- a/src/stream/CurlInput.h
+++ b/src/stream/CurlInput.h
@@ -18,6 +18,9 @@
 
 #define SEEK_POSSIBLE 0x10 // flag used to check if protocol allows seeks
 
+namespace ffmpegdirect
+{
+
 class CurlInput
 {
 public:
@@ -43,3 +46,5 @@ protected:
   unsigned int m_flags = 0;
   std::string m_content;
 };
+
+} //namespace ffmpegdirect

--- a/src/stream/DemuxStream.cpp
+++ b/src/stream/DemuxStream.cpp
@@ -10,7 +10,6 @@
 
 #include "../utils/Log.h"
 #include "url/URL.h"
-#include "FFmpegLog.h"
 
 #ifdef TARGET_POSIX
 #include "platform/posix/XTimeUtils.h"
@@ -32,6 +31,8 @@ extern "C" {
 }
 
 #include <p8-platform/util/StringUtils.h>
+
+using namespace ffmpegdirect;
 
 /***********************************************************
 * InputSteam Client AddOn specific public library functions

--- a/src/stream/DemuxStream.h
+++ b/src/stream/DemuxStream.h
@@ -32,6 +32,9 @@ extern "C"
 #pragma warning(pop)
 #endif
 
+namespace ffmpegdirect
+{
+
 class DemuxStream
 {
 public:
@@ -213,3 +216,5 @@ public:
   AVCodecParserContext* m_parserCtx = nullptr;
   AVCodecContext* m_codecCtx = nullptr;
 };
+
+} //namespace ffmpegdirect

--- a/src/stream/FFmpegCatchupStream.cpp
+++ b/src/stream/FFmpegCatchupStream.cpp
@@ -35,6 +35,7 @@ extern "C" {
 
 //#include "platform/posix/XTimeUtils.h"
 
+#include <kodi/Filesystem.h>
 #include <p8-platform/util/StringUtils.h>
 
 using namespace ffmpegdirect;
@@ -401,14 +402,16 @@ void FormatUnits(time_t tTime, const std::string& name, std::string &urlFormatSt
 void FormatTime(const char ch, const struct tm *pTime, std::string &urlFormatString)
 {
   char str[] = { '{', ch, '}', 0 };
-  auto pos = urlFormatString.find(str);
-  if (pos != std::string::npos)
+  size_t pos = urlFormatString.find(str);
+  while (pos != std::string::npos)
   {
     char buff[256], timeFmt[3];
     std::snprintf(timeFmt, sizeof(timeFmt), "%%%c", ch);
     std::strftime(buff, sizeof(buff), timeFmt, pTime);
     if (std::strlen(buff) > 0)
       urlFormatString.replace(pos, 3, buff);
+
+    pos = urlFormatString.find(str);
   }
 }
 

--- a/src/stream/FFmpegCatchupStream.h
+++ b/src/stream/FFmpegCatchupStream.h
@@ -11,6 +11,9 @@
 #include "FFmpegStream.h"
 #include "../utils/HttpProxy.h"
 
+namespace ffmpegdirect
+{
+
 static const int VIDEO_PLAYER_BUFFER_SECONDS = 10;
 static const int TERMINATING_SECOND_STREAM_MIN_SEEK_FROM_LIVE_TIME = 60;
 static const int TERMINATING_MINUTE_STREAM_MIN_SEEK_FROM_LIVE_TIME = 120;
@@ -19,22 +22,8 @@ class FFmpegCatchupStream : public FFmpegStream
 {
 public:
   FFmpegCatchupStream(IManageDemuxPacket* demuxPacketManager,
-                      const OpenMode& openMode,
-                      const ffmpegdirect::utils::HttpProxy& httpProxy,
-                      std::string& defaultUrl,
-                      bool playbackAsLive,
-                      time_t programmeStartTime,
-                      time_t programmeEndTime,
-                      std::string& catchupUrlFormatString,
-                      std::string& catchupUrlNearLiveFormatString,
-                      time_t catchupBufferStartTime,
-                      time_t catchupBufferEndTime,
-                      long long catchupBufferOffset,
-                      bool catchupTerminates,
-                      int catchupGranularity,
-                      int timezoneShift,
-                      int defaultProgrammeDuration,
-                      std::string& m_programmeCatchupId);
+                      const Properties props,
+                      const HttpProxy& httpProxy);
   ~FFmpegCatchupStream();
 
   virtual bool Open(const std::string& streamUrl, const std::string& mimeType, bool isRealTimeStream, const std::string& programProperty) override;
@@ -54,12 +43,12 @@ public:
 
 protected:
   void UpdateCurrentPTS() override;
-  bool CheckReturnEmptryOnPacketResult(int result) override;
+  bool CheckReturnEmptyOnPacketResult(int result) override;
 
   long long GetCurrentLiveOffset() { return std::time(nullptr) - m_catchupBufferStartTime; }
   bool SeekDistanceSupported(int64_t seekBufferOffset);
   bool TargetDistanceFromLiveSupported(long long secondsFromLive);
-  const std::string GetDateTime(time_t time) 
+  const std::string GetDateTime(time_t time)
   {
     std::tm timeStruct = *localtime(&time);
     char buffer[32];
@@ -95,3 +84,5 @@ protected:
   bool m_lastPacketWasAvoidedEOF = false;
   bool m_seekCorrectsEOF = false;
 };
+
+} //namespace ffmpegdirect

--- a/src/stream/FFmpegLog.cpp
+++ b/src/stream/FFmpegLog.cpp
@@ -20,6 +20,8 @@
 
 #include <p8-platform/util/StringUtils.h>
 
+using namespace ffmpegdirect;
+
 static thread_local CFFmpegLog* CFFmpegLogTls;
 
 void CFFmpegLog::SetLogLevel(int level)

--- a/src/stream/FFmpegLog.cpp
+++ b/src/stream/FFmpegLog.cpp
@@ -8,80 +8,74 @@
 
 #include "FFmpegLog.h"
 
-// #include "ServiceBroker.h"
-// #include "settings/AdvancedSettings.h"
-// #include "settings/SettingsComponent.h"
 #include "threads/CriticalSection.h"
 #include "threads/Thread.h"
-//#include "utils/StringUtils.h"
 #include "../utils/Log.h"
 
 #include <map>
 
+#include <kodi/General.h>
 #include <p8-platform/util/StringUtils.h>
 
 using namespace ffmpegdirect;
 
-static thread_local CFFmpegLog* CFFmpegLogTls;
+static thread_local FFmpegLog* CFFmpegDirectLogTls;
 
-void CFFmpegLog::SetLogLevel(int level)
+void FFmpegLog::SetLogLevel(int level)
 {
-  CFFmpegLog::ClearLogLevel();
-  CFFmpegLog *log = new CFFmpegLog();
+  FFmpegLog::ClearLogLevel();
+  FFmpegLog *log = new FFmpegLog();
   log->level = level;
-  CFFmpegLogTls = log;
+  CFFmpegDirectLogTls = log;
 }
 
-int CFFmpegLog::GetLogLevel()
+int FFmpegLog::GetLogLevel()
 {
-  CFFmpegLog* log = CFFmpegLogTls;
+  FFmpegLog* log = CFFmpegDirectLogTls;
   if (!log)
     return -1;
   return log->level;
 }
 
-void CFFmpegLog::ClearLogLevel()
+void FFmpegLog::ClearLogLevel()
 {
-  CFFmpegLog* log = CFFmpegLogTls;
-  CFFmpegLogTls = nullptr;
+  FFmpegLog* log = CFFmpegDirectLogTls;
+  CFFmpegDirectLogTls = nullptr;
   if (log)
     delete log;
 }
 
-static CCriticalSection m_logSection;
-std::map<const CThread*, std::string> g_logbuffer;
+static CCriticalSection m_ffmpegdirectLogSection;
+std::map<const CThread*, std::string> g_ffmpegdirectLogbuffer;
 
 void ff_flush_avutil_log_buffers(void)
 {
-  CSingleLock lock(m_logSection);
+  CSingleLock lock(m_ffmpegdirectLogSection);
   /* Loop through the logbuffer list and remove any blank buffers
      If the thread using the buffer is still active, it will just
      add a new buffer next time it writes to the log */
   std::map<const CThread*, std::string>::iterator it;
-  for (it = g_logbuffer.begin(); it != g_logbuffer.end(); )
+  for (it = g_ffmpegdirectLogbuffer.begin(); it != g_ffmpegdirectLogbuffer.end(); )
     if ((*it).second.empty())
-      g_logbuffer.erase(it++);
+      g_ffmpegdirectLogbuffer.erase(it++);
     else
       ++it;
 }
 
 void ff_avutil_log(void* ptr, int level, const char* format, va_list va)
 {
-  CSingleLock lock(m_logSection);
+  CSingleLock lock(m_ffmpegdirectLogSection);
   const CThread* threadId = CThread::GetCurrentThread();
-  std::string &buffer = g_logbuffer[threadId];
+  std::string &buffer = g_ffmpegdirectLogbuffer[threadId];
 
   AVClass* avc= ptr ? *(AVClass**)ptr : NULL;
 
   int maxLevel = AV_LOG_WARNING;
-  if (CFFmpegLog::GetLogLevel() > 0)
+  if (FFmpegLog::GetLogLevel() > 0)
     maxLevel = AV_LOG_INFO;
 
-  // if (level > maxLevel &&
-  //    !CServiceBroker::GetSettingsComponent()->GetAdvancedSettings()->CanLogComponent(LOGFFMPEG))
-  //   return;
-  // else if (CServiceBroker::GetSettingsComponent()->GetAdvancedSettings()->m_logLevel <= LOG_LEVEL_NORMAL)
-  //   return;
+  if (level > maxLevel && !kodi::GetSettingBoolean("allowFFmpegLogging"))
+    return;
 
   LogLevel type;
   switch (level)

--- a/src/stream/FFmpegLog.h
+++ b/src/stream/FFmpegLog.h
@@ -13,30 +13,8 @@
 
 extern "C" {
 #include <libavcodec/avcodec.h>
-#include <libavformat/avformat.h>
-#include <libavutil/avutil.h>
 #include <libavutil/log.h>
-#include <libavutil/ffversion.h>
-#include <libavfilter/avfilter.h>
-#include <libpostproc/postprocess.h>
 }
-
-// inline int PPCPUFlags()
-// {
-//   unsigned int cpuFeatures = CServiceBroker::GetCPUInfo()->GetCPUFeatures();
-//   int flags = 0;
-
-//   if (cpuFeatures & CPU_FEATURE_MMX)
-//     flags |= PP_CPU_CAPS_MMX;
-//   if (cpuFeatures & CPU_FEATURE_MMX2)
-//     flags |= PP_CPU_CAPS_MMX2;
-//   if (cpuFeatures & CPU_FEATURE_3DNOW)
-//     flags |= PP_CPU_CAPS_3DNOW;
-//   if (cpuFeatures & CPU_FEATURE_ALTIVEC)
-//     flags |= PP_CPU_CAPS_ALTIVEC;
-
-//   return flags;
-// }
 
 // callback used for logging
 void ff_avutil_log(void* ptr, int level, const char* format, va_list va);
@@ -45,7 +23,7 @@ void ff_flush_avutil_log_buffers(void);
 namespace ffmpegdirect
 {
 
-class CFFmpegLog
+class FFmpegLog
 {
 public:
   static void SetLogLevel(int level);

--- a/src/stream/FFmpegLog.h
+++ b/src/stream/FFmpegLog.h
@@ -42,6 +42,9 @@ extern "C" {
 void ff_avutil_log(void* ptr, int level, const char* format, va_list va);
 void ff_flush_avutil_log_buffers(void);
 
+namespace ffmpegdirect
+{
+
 class CFFmpegLog
 {
 public:
@@ -51,3 +54,4 @@ public:
   int level;
 };
 
+} //namespace ffmpegdirect

--- a/src/stream/FFmpegStream.cpp
+++ b/src/stream/FFmpegStream.cpp
@@ -47,6 +47,7 @@ extern "C" {
 //#include "platform/posix/XTimeUtils.h"
 
 #include <kodi/Filesystem.h>
+#include <kodi/Network.h>
 #include <p8-platform/util/StringUtils.h>
 
 using namespace ffmpegdirect;
@@ -2243,8 +2244,7 @@ AVDictionary* FFmpegStream::GetFFMpegOptionsFromInput()
     if (!hasUserAgent)
     {
       // set default xbmc user-agent.
-      // TODO:
-      av_dict_set(&options, "user_agent", "Kodi", 0);//CServiceBroker::GetSettingsComponent()->GetAdvancedSettings()->m_userAgent.c_str(), 0);
+      av_dict_set(&options, "user_agent", kodi::network::GetUserAgent().c_str(), 0);
     }
 
     if (!headers.empty())
@@ -2253,9 +2253,8 @@ AVDictionary* FFmpegStream::GetFFMpegOptionsFromInput()
     if (!hasCookies)
     {
       std::string cookies;
-      // TODO: once available in koid::vfs
-      // if (XFILE::CCurlFile::GetCookies(url, cookies))
-      //   av_dict_set(&options, "cookies", cookies.c_str(), 0);
+      if (kodi::vfs::GetCookies(m_streamUrl, cookies))
+        av_dict_set(&options, "cookies", cookies.c_str(), 0);
     }
   }
 

--- a/src/stream/FFmpegStream.cpp
+++ b/src/stream/FFmpegStream.cpp
@@ -137,7 +137,7 @@ FFmpegStream::FFmpegStream(IManageDemuxPacket* demuxPacketManager, const OpenMod
   m_checkTransportStream = false;
   m_dtsAtDisplayTime = DVD_NOPTS_VALUE;
 
-  CFFmpegLog::SetLogLevel(-100);
+  FFmpegLog::SetLogLevel(AV_LOG_INFO);
   av_log_set_callback(ff_avutil_log);
 }
 
@@ -145,6 +145,7 @@ FFmpegStream::~FFmpegStream()
 {
   Dispose();
   ff_flush_avutil_log_buffers();
+  FFmpegLog::ClearLogLevel();
 }
 
 bool FFmpegStream::Open(const std::string& streamUrl, const std::string& mimeType, bool isRealTimeStream, const std::string& programProperty)

--- a/src/stream/FFmpegStream.cpp
+++ b/src/stream/FFmpegStream.cpp
@@ -833,7 +833,7 @@ bool FFmpegStream::Open(bool fileinfo)
           }
         }
       }
-      else if (m_pFormatContext->iformat && strcmp(m_pFormatContext->iformat->name, "hls,applehttp") == 0)
+      else if (m_pFormatContext->iformat && strcmp(m_pFormatContext->iformat->name, "hls") == 0)
       {
         nProgram = HLSSelectProgram();
       }
@@ -878,13 +878,6 @@ bool FFmpegStream::Open(bool fileinfo)
     if (!Open(false))
       return false;
     m_pFormatContext->duration = duration;
-  }
-
-  // seems to be a bug in ffmpeg, hls jumps back to start after a couple of seconds
-  // this cures the issue
-  if (m_pFormatContext->iformat && strcmp(m_pFormatContext->iformat->name, "hls,applehttp") == 0)
-  {
-    SeekTime(0);
   }
 
   return true;

--- a/src/stream/FFmpegStream.cpp
+++ b/src/stream/FFmpegStream.cpp
@@ -26,8 +26,6 @@
 
 // #include <kodi/addon-instance/Inputstream.h>
 
-using namespace ffmpegdirect::utils;
-
 #include <chrono>
 #include <ctime>
 
@@ -50,6 +48,8 @@ extern "C" {
 
 #include <kodi/Filesystem.h>
 #include <p8-platform/util/StringUtils.h>
+
+using namespace ffmpegdirect;
 
 /***********************************************************
 * InputSteam Client AddOn specific public library functions
@@ -255,7 +255,7 @@ void FFmpegStream::DemuxReset()
 {
   m_demuxResetOpenSuccess = false;
   Dispose();
-  // Here we update the filename and call reset in case the 
+  // Here we update the filename and call reset in case the
   // implementation needs to restart the stream
   m_curlInput->SetFilename(m_streamUrl);
   m_curlInput->Reset();
@@ -320,7 +320,7 @@ DemuxPacket* FFmpegStream::DemuxRead()
       // timeout, probably no real error, return empty packet
       bReturnEmpty = true;
     }
-    else if (CheckReturnEmptryOnPacketResult(m_pkt.result))  
+    else if (CheckReturnEmptyOnPacketResult(m_pkt.result))
     {
       bReturnEmpty = true;
     }
@@ -360,7 +360,7 @@ DemuxPacket* FFmpegStream::DemuxRead()
         // update streams
         CreateStreams(m_program);
 
-        pPacket = m_demuxPacketMamnager->AllocateDemuxPacketFromInputStreamAPI(0);
+        pPacket = m_demuxPacketManager->AllocateDemuxPacketFromInputStreamAPI(0);
         pPacket->iStreamId = DMX_SPECIALID_STREAMCHANGE;
         pPacket->demuxerId = m_demuxerId;
 
@@ -378,7 +378,7 @@ DemuxPacket* FFmpegStream::DemuxRead()
           {
             if (m_pkt.pkt.stream_index == (int)m_pFormatContext->programs[m_program]->stream_index[i])
             {
-              pPacket = m_demuxPacketMamnager->AllocateDemuxPacketFromInputStreamAPI(m_pkt.pkt.size);
+              pPacket = m_demuxPacketManager->AllocateDemuxPacketFromInputStreamAPI(m_pkt.pkt.size);
               break;
             }
           }
@@ -387,7 +387,7 @@ DemuxPacket* FFmpegStream::DemuxRead()
             bReturnEmpty = true;
         }
         else
-          pPacket = m_demuxPacketMamnager->AllocateDemuxPacketFromInputStreamAPI(m_pkt.pkt.size);
+          pPacket = m_demuxPacketManager->AllocateDemuxPacketFromInputStreamAPI(m_pkt.pkt.size);
       }
       else
         bReturnEmpty = true;
@@ -448,7 +448,7 @@ DemuxPacket* FFmpegStream::DemuxRead()
   }
   } // end of lock scope
   if (bReturnEmpty && !pPacket)
-    pPacket = m_demuxPacketMamnager->AllocateDemuxPacketFromInputStreamAPI(0);
+    pPacket = m_demuxPacketManager->AllocateDemuxPacketFromInputStreamAPI(0);
 
   if (!pPacket)
     return nullptr;
@@ -488,8 +488,8 @@ DemuxPacket* FFmpegStream::DemuxRead()
     }
     if (!stream)
     {
-      m_demuxPacketMamnager->FreeDemuxPacketFromInputStreamAPI(pPacket);
-      pPacket = m_demuxPacketMamnager->AllocateDemuxPacketFromInputStreamAPI(0);
+      m_demuxPacketManager->FreeDemuxPacketFromInputStreamAPI(pPacket);
+      pPacket = m_demuxPacketManager->AllocateDemuxPacketFromInputStreamAPI(0);
       return pPacket;
     }
 
@@ -1128,7 +1128,7 @@ bool FFmpegStream::OpenWithCURL(AVInputFormat* iformat)
     av_dict_free(&options);
     return false;
   }
-  av_dict_free(&options);  
+  av_dict_free(&options);
 
   return true;
 }
@@ -1458,7 +1458,7 @@ bool FFmpegStream::SeekTime(double time, bool backwards, double* startpts)
     {
       DemuxPacket* pkt = DemuxRead();
       if (pkt)
-        m_demuxPacketMamnager->FreeDemuxPacketFromInputStreamAPI(pkt);
+        m_demuxPacketManager->FreeDemuxPacketFromInputStreamAPI(pkt);
       else
         std::this_thread::sleep_for(std::chrono::milliseconds(10));
       m_pkt.result = -1;
@@ -2036,7 +2036,7 @@ DemuxStream* FFmpegStream::AddStream(int streamIdx)
 //         pStream->discard = AVDISCARD_ALL;
 //         delete stream;
 //         return nullptr;
-//       }  
+//       }
 //       stream->dvdNavId = pStream->id;
 
 //       auto it = std::find_if(m_streams.begin(), m_streams.end(),
@@ -2407,7 +2407,7 @@ bool FFmpegStream::SeekChapter(int chapter)
   return SeekTime(DVD_TIME_TO_MSEC(dts), true);
 }
 
-bool FFmpegStream::CheckReturnEmptryOnPacketResult(int result)
+bool FFmpegStream::CheckReturnEmptyOnPacketResult(int result)
 {
   return false;
 }
@@ -2422,7 +2422,7 @@ void FFmpegStream::GetL16Parameters(int &channels, int &samplerate)
 
     file.Close();
   }
-  
+
   if (!content.empty())
   {
     StringUtils::ToLower(content);

--- a/src/stream/FFmpegStream.h
+++ b/src/stream/FFmpegStream.h
@@ -12,6 +12,7 @@
 #include "threads/SystemClock.h"
 
 #include "../utils/HttpProxy.h"
+#include "../utils/Properties.h"
 #include "BaseStream.h"
 #include "DemuxStream.h"
 #include "CurlInput.h"
@@ -45,6 +46,9 @@ extern "C"
 
 struct StereoModeConversionMap;
 
+namespace ffmpegdirect
+{
+
 enum class TRANSPORT_STREAM_STATE
 {
   NONE,
@@ -52,20 +56,12 @@ enum class TRANSPORT_STREAM_STATE
   NOTREADY,
 };
 
-enum class OpenMode
-  : int // same type as addon settings
-{
-  DEFAULT = 0,
-  FFMPEG,
-  CURL
-};
-
 class FFmpegStream
   : public BaseStream
 {
 public:
-  FFmpegStream(IManageDemuxPacket* demuxPacketManager, const OpenMode& openMode, const ffmpegdirect::utils::HttpProxy& httpProxy);
-  FFmpegStream(IManageDemuxPacket* demuxPacketManager, const OpenMode& openMode, std::shared_ptr<CurlInput> curlInput, const ffmpegdirect::utils::HttpProxy& httpProxy);
+  FFmpegStream(IManageDemuxPacket* demuxPacketManager, const OpenMode& openMode, const HttpProxy& httpProxy);
+  FFmpegStream(IManageDemuxPacket* demuxPacketManager, const OpenMode& openMode, std::shared_ptr<CurlInput> curlInput, const HttpProxy& httpProxy);
   ~FFmpegStream();
 
   virtual bool Open(const std::string& streamUrl, const std::string& mimeType, bool isRealTimeStream, const std::string& programProperty) override;
@@ -112,7 +108,7 @@ protected:
   virtual std::string GetStreamCodecName(int iStreamId);
   virtual void UpdateCurrentPTS();
   bool IsPaused() { return m_speed == DVD_PLAYSPEED_PAUSE; }
-  virtual bool CheckReturnEmptryOnPacketResult(int result);
+  virtual bool CheckReturnEmptyOnPacketResult(int result);
 
   int64_t m_demuxerId;
   CCriticalSection m_critSection;
@@ -145,7 +141,7 @@ private:
   void ParsePacket(AVPacket* pkt);
   TRANSPORT_STREAM_STATE TransportStreamAudioState();
   TRANSPORT_STREAM_STATE TransportStreamVideoState();
-  bool IsTransportStreamReady();  
+  bool IsTransportStreamReady();
   bool IsProgramChange();
   void StoreSideData(DemuxPacket *pkt, AVPacket *src);
 
@@ -198,6 +194,8 @@ private:
   bool m_isRealTimeStream;
   bool m_opened;
 
-  ffmpegdirect::utils::HttpProxy m_httpProxy;
+  HttpProxy m_httpProxy;
   OpenMode m_openMode;
 };
+
+} //namespace ffmpegdirect

--- a/src/stream/IManageDemuxPacket.h
+++ b/src/stream/IManageDemuxPacket.h
@@ -10,6 +10,9 @@
 
 #include <kodi/addon-instance/Inputstream.h>
 
+namespace ffmpegdirect
+{
+
 class IManageDemuxPacket
 {
 public:
@@ -19,3 +22,5 @@ public:
   virtual DemuxPacket* AllocateEncryptedDemuxPacketFromInputStreamAPI(int dataSize, unsigned int encryptedSubsampleCount) = 0;
   virtual void FreeDemuxPacketFromInputStreamAPI(DemuxPacket* packet) = 0;
 };
+
+} //namespace ffmpegdirect

--- a/src/stream/TimeshiftBuffer.cpp
+++ b/src/stream/TimeshiftBuffer.cpp
@@ -1,0 +1,297 @@
+/*
+ *  Copyright (C) 2005-2020 Team Kodi
+ *  https://kodi.tv
+ *
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *  See LICENSE.md for more information.
+ */
+
+#include "TimeshiftBuffer.h"
+
+#include "../utils/Log.h"
+
+#include <kodi/Filesystem.h>
+#include <p8-platform/util/StringUtils.h>
+
+using namespace ffmpegdirect;
+
+TimeshiftBuffer::TimeshiftBuffer(IManageDemuxPacket* demuxPacketManager)
+  : m_demuxPacketManager(demuxPacketManager)
+{
+  m_timeshiftBufferPath = kodi::GetSettingString("timeshiftBufferPath");
+  if (m_timeshiftBufferPath.empty())
+    m_timeshiftBufferPath = DEFAULT_TIMESHIFT_BUFFER_PATH;
+  kodi::vfs::CreateDirectory(m_timeshiftBufferPath);
+}
+
+TimeshiftBuffer::~TimeshiftBuffer()
+{
+  if (!m_streamId.empty())
+  {
+    for (int segmentId = m_earliestOnDiskSegmentId; segmentId <= m_writeSegment->GetSegmentId(); segmentId++)
+    {
+      std::string segmentFilename = StringUtils::Format("%s-%08d.seg", m_streamId.c_str(), segmentId);
+      Log(LOGLEVEL_DEBUG, "%s - Deleteing on disk segment - Segment ID: %d, Segment Filename: %s", __FUNCTION__, segmentId, segmentFilename.c_str());
+
+      kodi::vfs::DeleteFile(m_timeshiftBufferPath + "/" + segmentFilename);
+    }
+  }
+
+  m_segmentIndexFileHandle.Close();
+  kodi::vfs::DeleteFile(m_segmentIndexFilePath);
+}
+
+void TimeshiftBuffer::Start(const std::string& streamId)
+{
+  m_segmentIndexFilePath = m_timeshiftBufferPath + "/" + streamId + ".idx";
+  if (!m_segmentIndexFileHandle.OpenFileForWrite(m_segmentIndexFilePath))
+  {
+    Log(LOGLEVEL_ERROR, "%s - Failed to open segment index file on disk: %s", __FUNCTION__, m_segmentIndexFilePath.c_str());
+  }
+
+  m_streamId = streamId;
+
+  m_startedTimePoint = std::chrono::high_resolution_clock::now();
+  m_startTime = std::time(nullptr);
+
+  m_firstSegment = std::make_shared<TimeshiftSegment>(m_demuxPacketManager, m_streamId, m_currentSegmentIndex, m_timeshiftBufferPath);
+  m_writeSegment = m_firstSegment;
+  m_segmentTimeIndexMap[0] = m_writeSegment;
+  m_currentSegmentIndex++;
+  m_segmentTotalCount++;
+  m_readSegment = m_writeSegment;
+}
+
+void TimeshiftBuffer::AddPacket(DemuxPacket* packet)
+{
+  std::lock_guard<std::mutex> lock(m_mutex);
+
+  // Useful for debugging the initial set of packets in a stream
+  if (m_readingInitialPackets)
+  {
+    Log(LOGLEVEL_DEBUG, "%s - Writing first segment - PTS: %f, DTA: %f, pts sec: %f, dts sec: %f", __FUNCTION__, packet->pts, packet->dts, packet->pts / DVD_TIME_BASE, packet->dts / DVD_TIME_BASE);
+
+    // Note that this is a heuristic for a packet stream stabilising, unknown if it's true of all stream types
+    if (packet->pts != DVD_NOPTS_VALUE && packet->pts == packet->dts)
+      m_readingInitialPackets = false;
+  }
+
+  int secondsSinceStart = 0;
+  if (packet->pts != DVD_NOPTS_VALUE && packet->pts > 0)
+    secondsSinceStart = packet->pts / DVD_TIME_BASE;
+
+  if (secondsSinceStart - m_lastSegmentSecondsSinceStart >= TIMESHIFT_SEGMENT_LENGTH_SECS)
+  {
+    m_readingInitialPackets = false;
+
+    if (secondsSinceStart != m_lastPacketSecondsSinceStart)
+    {
+      m_readingInitialPackets = false;
+
+      std::shared_ptr<TimeshiftSegment> m_previousWriteSegment = m_writeSegment;
+      m_previousWriteSegment->MarkAsComplete();
+
+      Log(LOGLEVEL_INFO, "%s - Writing new segment - seconds: %d, last seg seconds: %d, last seg packet count: %d, new seg index: %d, pts %.2f, dts: %.2f, pts sec: %.0f, dts sec: %.0f",
+                         __FUNCTION__, secondsSinceStart, m_lastSegmentSecondsSinceStart, m_previousWriteSegment->GetPacketCount(), m_currentSegmentIndex,
+                         packet->pts, packet->dts, packet->pts / DVD_TIME_BASE, packet->dts / DVD_TIME_BASE);
+
+      if (m_segmentIndexFileHandle.IsOpen())
+      {
+        //std::string line = std::to_string(m_previousWriteSegment->GetSegmentId()) + "," + std::to_string(m_lastSegmentSecondsSinceStart) + "," + std::to_string(secondsSinceStart) + "\n";
+        std::string line = StringUtils::Format("%9d,%9d,%9d\n", m_previousWriteSegment->GetSegmentId(), m_lastSegmentSecondsSinceStart, secondsSinceStart); // 30 characters per line
+        m_segmentIndexFileHandle.Write(line.c_str(), line.length());
+      }
+
+      if (m_segmentTimeIndexMap.size() > MAX_IN_MEMORY_SEGMENT_INDEXES)
+        RemoveOldestInMemorySegment();
+
+      m_writeSegment = std::make_shared<TimeshiftSegment>(m_demuxPacketManager, m_streamId, m_currentSegmentIndex, m_timeshiftBufferPath);
+      m_previousWriteSegment->SetNextSegment(m_writeSegment);
+      m_segmentTimeIndexMap[secondsSinceStart] = m_writeSegment;
+      m_currentSegmentIndex++;
+      m_segmentTotalCount++;
+      m_lastSegmentSecondsSinceStart = secondsSinceStart;
+    }
+  }
+  m_lastPacketSecondsSinceStart = secondsSinceStart;
+
+  m_writeSegment->AddPacket(packet);
+}
+
+void TimeshiftBuffer::RemoveOldestInMemorySegment()
+{
+  std::shared_ptr<TimeshiftSegment> oldFirstSegment = m_firstSegment;
+
+  m_firstSegment = oldFirstSegment->GetNextSegment();
+  oldFirstSegment->SetNextSegment(nullptr);
+  int timeToRemove = m_segmentTimeIndexMap.cbegin()->first;
+  m_segmentTimeIndexMap.erase(timeToRemove);
+  m_minInMemorySeekTimeIndex = m_segmentTimeIndexMap.cbegin()->first;
+
+  Log(LOGLEVEL_DEBUG, "%s - Removed oldest in memory segment with ID: %d", __FUNCTION__, oldFirstSegment->GetSegmentId());
+
+  if (!m_paused && m_segmentTotalCount > MAX_ON_DISK_SEGMENTS && m_currentDemuxTimeIndex > m_minOnDiskSeekTimeIndex)
+  {
+    while (m_segmentTotalCount > MAX_ON_DISK_SEGMENTS && m_currentDemuxTimeIndex > m_minOnDiskSeekTimeIndex)
+    {
+      std::string segmentFilename = StringUtils::Format("%s-%08d.seg", m_streamId.c_str(), m_earliestOnDiskSegmentId);
+      if (kodi::vfs::FileExists(m_timeshiftBufferPath + "/" + segmentFilename))
+      {
+        kodi::vfs::DeleteFile(m_timeshiftBufferPath + "/" + segmentFilename);
+        Log(LOGLEVEL_INFO, "%s - Removed oldest on disk segment with ID: %d - currentDemuxTimeSeconds: %d, min on disk time: %d", __FUNCTION__, m_earliestOnDiskSegmentId, m_currentDemuxTimeIndex, m_minOnDiskSeekTimeIndex);
+        m_earliestOnDiskSegmentId++;
+        m_segmentTotalCount--;
+
+        SegmentIndexOnDiskEntry indexEntry = SearchOnDiskIndex(SegmentIndexSearchBy::SEGMENT_ID, m_earliestOnDiskSegmentId);
+
+        if (indexEntry.m_segmentId >= 0)
+          m_minOnDiskSeekTimeIndex = indexEntry.m_timeIndexStart;
+      }
+    }
+  }
+}
+
+DemuxPacket* TimeshiftBuffer::ReadPacket()
+{
+  std::lock_guard<std::mutex> lock(m_mutex);
+  DemuxPacket* packet = nullptr;
+
+  if (m_readSegment)
+  {
+    m_readSegment->LoadSegment();
+
+    packet = m_readSegment->ReadPacket();
+
+    if (!m_readSegment->HasPacketAvailable() && m_readSegment->ReadAllPackets())
+    {
+      std::shared_ptr<TimeshiftSegment> m_previousReadSegment = m_readSegment;
+
+      m_readSegment = m_readSegment->GetNextSegment();
+      if (!m_readSegment) // We need to load the next read segment from disk as it doesn't exist in memory
+      {
+        m_readSegment = std::make_shared<TimeshiftSegment>(m_demuxPacketManager, m_streamId, m_previousReadSegment->GetSegmentId() + 1, m_timeshiftBufferPath);
+        m_readSegment->ForceLoadSegment();
+      }
+      m_readSegment->ResetReadIndex();
+
+      m_previousReadSegment->ClearPackets();
+      if (m_readSegment)
+        Log(LOGLEVEL_INFO, "%s - Reading next segment with id: %d, packet count: %d", __FUNCTION__, m_readSegment->GetSegmentId(), m_readSegment->GetPacketCount());
+    }
+
+    if (packet && packet->pts != DVD_NOPTS_VALUE && packet->pts > 0)
+      m_currentDemuxTimeIndex = packet->pts / DVD_TIME_BASE;
+  }
+  else
+  {
+    packet = m_demuxPacketManager->AllocateDemuxPacketFromInputStreamAPI(0);
+  }
+
+  return packet;
+}
+
+bool TimeshiftBuffer::Seek(double timeMs)
+{
+  int seekSeconds = timeMs / 1000;
+  std::lock_guard<std::mutex> lock(m_mutex);
+
+  if (seekSeconds >= m_minInMemorySeekTimeIndex)
+  {
+    auto seekSegmentIndex = m_segmentTimeIndexMap.upper_bound(seekSeconds);
+    // Upper bound gets the segment after the one we want
+    if (seekSegmentIndex != m_segmentTimeIndexMap.begin())
+      --seekSegmentIndex;
+
+    if (seekSegmentIndex != m_segmentTimeIndexMap.end())
+      m_readSegment = seekSegmentIndex->second;
+    else // Jump to live segment
+      m_readSegment = m_segmentTimeIndexMap.rbegin()->second;
+
+    Log(LOGLEVEL_INFO, "%s - Buffer - SegmentID: %d, SeekSeconds: %d", __FUNCTION__, m_readSegment->GetSegmentId(), seekSeconds);
+
+    m_readSegment->LoadSegment();
+    if (m_readSegment->Seek(timeMs))
+      return true;
+  }
+  else // We need to find the segment in the index file as it's not in memory
+  {
+    SegmentIndexOnDiskEntry indexEntry = SearchOnDiskIndex(SegmentIndexSearchBy::TIME_INDEX, seekSeconds);
+
+    if (indexEntry.m_segmentId >= 0)
+    {
+      std::string segmentFilename = StringUtils::Format("%s-%08d.seg", m_streamId.c_str(), indexEntry.m_segmentId);
+
+      if (kodi::vfs::FileExists(m_timeshiftBufferPath + "/" + segmentFilename))
+      {
+        m_readSegment = std::make_shared<TimeshiftSegment>(m_demuxPacketManager, m_streamId, indexEntry.m_segmentId, m_timeshiftBufferPath);
+        m_readSegment->ForceLoadSegment();
+        return true;
+      }
+    }
+  }
+
+  return false;
+}
+
+void TimeshiftBuffer::SetPaused(bool paused)
+{
+  std::lock_guard<std::mutex> lock(m_mutex);
+
+  if (paused)
+  {
+    // If the read segment is not in memory clear it's next pointer so stays only on disk
+    // Otherwise the the shared pointer will stay referenced.
+    if (m_readSegment->GetSegmentId() < m_firstSegment->GetSegmentId())
+      m_readSegment->SetNextSegment(nullptr);
+  }
+
+  Log(LOGLEVEL_INFO, "%s - Stream %s - time seconds: %d", __FUNCTION__, paused ? "paused" : "resumed", m_currentDemuxTimeIndex);
+
+  m_paused = paused;
+}
+
+SegmentIndexOnDiskEntry TimeshiftBuffer::SearchOnDiskIndex(const SegmentIndexSearchBy& segmentIndexSearchBy, int searchValue)
+{
+  SegmentIndexOnDiskEntry entry;
+
+  int seekStart = 0;
+  // Here we calulate an exact line number for segment id search
+  // and a definitely below line number for time index searches
+  if (segmentIndexSearchBy == SegmentIndexSearchBy::SEGMENT_ID)
+    seekStart = searchValue * SEGMENT_INDEX_FILE_LINE_LENGTH;
+  else if (segmentIndexSearchBy == SegmentIndexSearchBy::TIME_INDEX)
+    seekStart = searchValue / TIMESHIFT_SEGMENT_LENGTH_SECS;
+
+  kodi::vfs::CFile readFileHandle;
+  if (readFileHandle.OpenFile(m_segmentIndexFilePath, ADDON_READ_NO_CACHE))
+  {
+    readFileHandle.Seek(seekStart);
+
+    std::string line;
+    bool foundSegmentOnDisk = false;
+    while (readFileHandle.ReadLine(line))
+    {
+      const auto& values = StringUtils::Split(line, ",");
+
+      if (values.size() == 3)
+      {
+        int segmentId = std::atoi(values[0].c_str());
+        int timeIndexStart = std::atoi(values[1].c_str());
+        int timeIndexEnd = std::atoi(values[2].c_str());
+
+        if ((segmentIndexSearchBy == SegmentIndexSearchBy::SEGMENT_ID && searchValue == segmentId) ||
+            (segmentIndexSearchBy == SegmentIndexSearchBy::TIME_INDEX && searchValue >= timeIndexStart && searchValue < timeIndexEnd))
+        {
+          entry.m_segmentId = segmentId;
+          entry.m_timeIndexStart = timeIndexStart;
+          entry.m_timeIndexEnd = timeIndexEnd;
+          break;
+        }
+      }
+    }
+
+    readFileHandle.Close();
+  }
+
+  return entry;
+}

--- a/src/stream/TimeshiftBuffer.h
+++ b/src/stream/TimeshiftBuffer.h
@@ -1,0 +1,123 @@
+/*
+ *  Copyright (C) 2005-2020 Team Kodi
+ *  https://kodi.tv
+ *
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *  See LICENSE.md for more information.
+ */
+
+#pragma once
+
+#include "IManageDemuxPacket.h"
+#include "TimeshiftSegment.h"
+
+#include <chrono>
+#include <map>
+#include <memory>
+#include <mutex>
+#include <vector>
+
+#include <kodi/addon-instance/Inputstream.h>
+
+namespace ffmpegdirect
+{
+
+constexpr int TIMESHIFT_SEGMENT_LENGTH_SECS = 12;
+constexpr int TIMESHIFT_SEGMENT_IN_MEMORY_INDEXED_LENGTH_SECS = 60 * 12; // 12 minutes
+constexpr int MAX_IN_MEMORY_SEGMENT_INDEXES = TIMESHIFT_SEGMENT_IN_MEMORY_INDEXED_LENGTH_SECS / TIMESHIFT_SEGMENT_LENGTH_SECS + 1;
+constexpr int TIMESHIFT_SEGMENT_ON_DISK_LENGTH_SECS = 60 * 60 * 4; // 4 hours
+constexpr int MAX_ON_DISK_SEGMENTS = (TIMESHIFT_SEGMENT_ON_DISK_LENGTH_SECS / TIMESHIFT_SEGMENT_LENGTH_SECS) + 1;
+constexpr int SEGMENT_INDEX_FILE_LINE_LENGTH = 30;
+
+struct SegmentIndexOnDiskEntry
+{
+  int m_segmentId = -1;
+  int m_timeIndexStart = -1;
+  int m_timeIndexEnd = -1;
+};
+
+enum class SegmentIndexSearchBy
+{
+  SEGMENT_ID,
+  TIME_INDEX
+};
+
+class TimeshiftBuffer
+{
+public:
+  TimeshiftBuffer(IManageDemuxPacket* demuxPacketManager);
+  ~TimeshiftBuffer();
+
+  void AddPacket(DemuxPacket* packet);
+  DemuxPacket* ReadPacket();
+  bool Seek(double timeMs);
+  void SetPaused(bool paused);
+
+  void Start(const std::string& streamId);
+
+  time_t GetStartTimeSecs() { return m_startTime; }
+
+  int GetSecondsSinceStart()
+  {
+    return std::chrono::duration_cast<std::chrono::seconds>(
+                      std::chrono::high_resolution_clock::now() - m_startedTimePoint).count();
+  }
+
+  int64_t GetMillisecondsSinceStart()
+  {
+    return std::chrono::duration_cast<std::chrono::milliseconds>(
+                      std::chrono::high_resolution_clock::now() - m_startedTimePoint).count();
+  }
+
+  int64_t GetEarliestSegmentMillisecondsSinceStart()
+  {
+    return m_minOnDiskSeekTimeIndex * 1000;
+  }
+
+  bool HasPacketAvailable()
+  {
+    std::lock_guard<std::mutex> lock(m_mutex);
+    return m_readSegment && m_readSegment->HasPacketAvailable();
+  }
+
+protected:
+  IManageDemuxPacket* m_demuxPacketManager;
+
+private:
+  void RemoveOldestInMemorySegment();
+  SegmentIndexOnDiskEntry SearchOnDiskIndex(const SegmentIndexSearchBy& segmentIndexSearchBy, int searchValue);
+
+  int m_lastPacketSecondsSinceStart = 0;
+  int m_lastSegmentSecondsSinceStart = 0;
+  int m_minInMemorySeekTimeIndex = 0;
+  int m_segmentInMemoryIndexOffset = 0;
+  int m_minOnDiskSeekTimeIndex = 0;
+
+  std::shared_ptr<TimeshiftSegment> m_firstSegment;
+  std::shared_ptr<TimeshiftSegment> m_readSegment;
+  std::shared_ptr<TimeshiftSegment> m_writeSegment;
+
+  std::map<int, std::shared_ptr<TimeshiftSegment>> m_segmentTimeIndexMap;
+  int m_currentSegmentIndex = 0;
+  int m_earliestOnDiskSegmentId = 0;
+  int m_segmentTotalCount = 0;
+
+  std::chrono::high_resolution_clock::time_point m_startedTimePoint;
+  time_t m_startTime;
+
+  std::string m_streamId;
+
+  bool m_readingInitialPackets = true;
+
+  kodi::vfs::CFile m_segmentIndexFileHandle;
+
+  std::string m_timeshiftBufferPath;
+  std::string m_segmentIndexFilePath;
+
+  std::mutex m_mutex;
+
+  int m_currentDemuxTimeIndex;
+  bool m_paused = false;
+};
+
+} //namespace ffmpegdirect

--- a/src/stream/TimeshiftSegment.cpp
+++ b/src/stream/TimeshiftSegment.cpp
@@ -1,0 +1,464 @@
+/*
+ *  Copyright (C) 2005-2020 Team Kodi
+ *  https://kodi.tv
+ *
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *  See LICENSE.md for more information.
+ */
+
+#include "TimeshiftSegment.h"
+
+#include "../utils/Log.h"
+
+extern "C"
+{
+#include <libavcodec/avcodec.h>
+}
+
+#include <kodi/DemuxCrypto.h>
+#include <p8-platform/util/StringUtils.h>
+
+using namespace ffmpegdirect;
+
+TimeshiftSegment::TimeshiftSegment(IManageDemuxPacket* demuxPacketManager, const std::string& streamId, int segmentId, const std::string& timeshiftBufferPath)
+  : m_demuxPacketManager(demuxPacketManager), m_streamId(streamId), m_segmentId(segmentId)
+{
+  m_segmentFilename = StringUtils::Format("%s-%08d.seg", streamId.c_str(), segmentId);
+  Log(LOGLEVEL_DEBUG, "%s - Segment ID: %d, Segment Filename: %s", __FUNCTION__, segmentId, m_segmentFilename.c_str());
+
+  m_timeshiftSegmentFilePath = timeshiftBufferPath + "/" + m_segmentFilename;
+
+  // Only open the file for writing if it doesn't exist
+  // If it does exist then this segment is being created to
+  // to load an out of memory segment for a seek operation
+  if (!kodi::vfs::FileExists(m_timeshiftSegmentFilePath))
+  {
+    if (m_fileHandle.OpenFileForWrite(m_timeshiftSegmentFilePath))
+    {
+      int32_t packetCountPlaceholder = 0;
+      m_fileHandle.Write(&packetCountPlaceholder, sizeof(packetCountPlaceholder));
+    }
+    else
+    {
+      Log(LOGLEVEL_ERROR, "%s - Failed to open segment file on disk: %s", __FUNCTION__, m_timeshiftSegmentFilePath.c_str());
+      m_persistSegments = false;
+    }
+  }
+}
+
+TimeshiftSegment::~TimeshiftSegment()
+{
+  m_fileHandle.Close();
+
+  for (auto& demuxPacket : m_packetBuffer)
+  {
+    delete[] demuxPacket->pData;
+    FreeSideData(demuxPacket);
+  }
+}
+
+void TimeshiftSegment::AddPacket(DemuxPacket* packet)
+{
+  std::shared_ptr<DemuxPacket> newPacket = std::make_shared<DemuxPacket>();
+
+  CopyPacket(packet, newPacket.get(), true);
+
+  m_demuxPacketManager->FreeDemuxPacketFromInputStreamAPI(packet);
+
+  std::lock_guard<std::mutex> lock(m_mutex);
+
+  //Checksum
+  if (m_persistSegments)
+  {
+    m_fileHandle.Write(&m_currentPacketIndex, sizeof(m_currentPacketIndex));
+    WritePacket(newPacket);
+  }
+
+  m_packetBuffer.emplace_back(newPacket);
+
+  int secondsSinceStart = 0;
+  if (packet->pts != DVD_NOPTS_VALUE && packet->pts > 0)
+    secondsSinceStart = packet->pts / DVD_TIME_BASE;
+
+  if (secondsSinceStart != m_lastPacketSecondsSinceStart)
+  {
+    m_packetTimeIndexMap[secondsSinceStart] = m_currentPacketIndex;
+    m_lastPacketSecondsSinceStart = secondsSinceStart;
+  }
+
+  m_currentPacketIndex++;
+}
+
+void TimeshiftSegment::CopyPacket(DemuxPacket* sourcePacket, DemuxPacket* newPacket, bool allocateData)
+{
+  // Note that this is not needed if allocating in kodi
+  if (allocateData)
+    newPacket->pData = new uint8_t[sourcePacket->iSize];
+
+  newPacket->iSize = sourcePacket->iSize;
+  if (newPacket->iSize)
+    memcpy(newPacket->pData, sourcePacket->pData, newPacket->iSize);
+  newPacket->iStreamId = sourcePacket->iStreamId;
+  newPacket->demuxerId = sourcePacket->demuxerId;
+  newPacket->iGroupId = sourcePacket->iGroupId;
+
+  CopySideData(sourcePacket, newPacket);
+
+  newPacket->pts = sourcePacket->pts;
+  newPacket->dts = sourcePacket->dts;
+  newPacket->duration = sourcePacket->duration;
+  newPacket->dispTime = sourcePacket->dispTime;
+  newPacket->recoveryPoint = sourcePacket->recoveryPoint;
+  newPacket->cryptoInfo = sourcePacket->cryptoInfo;
+}
+
+void TimeshiftSegment::CopySideData(DemuxPacket* sourcePacket, DemuxPacket* newPacket)
+{
+  newPacket->pSideData = nullptr;
+  newPacket->iSideDataElems = 0;
+  if (sourcePacket->iSideDataElems > 0)
+  {
+    AVPacket srcAvPacket;
+    av_init_packet(&srcAvPacket);
+    srcAvPacket.side_data = static_cast<AVPacketSideData*>(sourcePacket->pSideData);
+    srcAvPacket.side_data_elems = sourcePacket->iSideDataElems;
+
+    AVPacket newAvPacket;
+    av_init_packet(&newAvPacket);
+    av_packet_copy_props(&newAvPacket, &srcAvPacket);
+    newPacket->pSideData = newAvPacket.side_data;
+    newPacket->iSideDataElems = newAvPacket.side_data_elems;
+  }
+}
+
+void TimeshiftSegment::FreeSideData(std::shared_ptr<DemuxPacket>& packet)
+{
+  if (packet->iSideDataElems > 0)
+  {
+    AVPacket avPacket;
+    av_init_packet(&avPacket);
+    avPacket.side_data = (AVPacketSideData*) packet->pSideData;
+    avPacket.side_data_elems = packet->iSideDataElems;
+    av_packet_unref(&avPacket);
+  }
+}
+
+void TimeshiftSegment::WritePacket(std::shared_ptr<DemuxPacket>& packet)
+{
+  m_fileHandle.Write(&packet->iSize, sizeof(packet->iSize));
+  if (packet->iSize > 0)
+    m_fileHandle.Write(packet->pData, packet->iSize);
+
+  m_fileHandle.Write(&packet->iStreamId, sizeof(packet->iStreamId));
+  m_fileHandle.Write(&packet->demuxerId, sizeof(packet->demuxerId));
+  m_fileHandle.Write(&packet->iGroupId, sizeof(packet->iGroupId));
+
+  m_fileHandle.Write(&packet->iSideDataElems, sizeof(packet->iSideDataElems));
+
+  if (packet->iSideDataElems > 0)
+  {
+    AVPacketSideData* sideData = static_cast<AVPacketSideData*>(packet->pSideData);
+    for (int i = 0; i < packet->iSideDataElems; i++)
+    {
+      m_fileHandle.Write(&sideData[i].type, sizeof(sideData[i].type));
+      m_fileHandle.Write(&sideData[i].size, sizeof(sideData[i].size));
+      if (sideData[i].size > 0)
+        m_fileHandle.Write(sideData[i].data, sideData[i].size);
+    }
+  }
+
+  m_fileHandle.Write(&packet->pts, sizeof(packet->pts));
+  m_fileHandle.Write(&packet->dts, sizeof(packet->dts));
+  m_fileHandle.Write(&packet->duration, sizeof(packet->duration));
+  m_fileHandle.Write(&packet->recoveryPoint, sizeof(packet->recoveryPoint));
+
+  bool hasCryptoInfo = packet->cryptoInfo != nullptr;
+  m_fileHandle.Write(&hasCryptoInfo, sizeof(hasCryptoInfo));
+  if (hasCryptoInfo)
+  {
+    int numSubSamples = packet->cryptoInfo->numSubSamples;
+    m_fileHandle.Write(&numSubSamples, sizeof(numSubSamples));
+    m_fileHandle.Write(&packet->cryptoInfo->flags, sizeof(packet->cryptoInfo->flags));
+    if (numSubSamples > 0)
+    {
+      m_fileHandle.Write(packet->cryptoInfo->clearBytes, sizeof(uint16_t) * numSubSamples);
+      m_fileHandle.Write(packet->cryptoInfo->cipherBytes, sizeof(uint32_t) * numSubSamples);
+    }
+    m_fileHandle.Write(packet->cryptoInfo->iv, sizeof(uint8_t) * 16);
+    m_fileHandle.Write(packet->cryptoInfo->kid, sizeof(uint8_t) * 16);
+  }
+}
+
+void TimeshiftSegment::ForceLoadSegment()
+{
+  m_loaded = false;
+  LoadSegment();
+}
+
+void TimeshiftSegment::LoadSegment()
+{
+  std::lock_guard<std::mutex> lock(m_mutex);
+
+  if (!m_loaded && m_fileHandle.OpenFile(m_timeshiftSegmentFilePath, ADDON_READ_NO_CACHE))
+  {
+    int32_t packetCount;
+    m_fileHandle.Read(&packetCount, sizeof(packetCount));
+
+    for (int i = 0; i < packetCount; i++)
+    {
+      std::shared_ptr<DemuxPacket> newPacket = std::make_shared<DemuxPacket>();
+      int loadedPacketIndex = LoadPacket(newPacket);
+      // Checksum does not match
+      if (loadedPacketIndex != i)
+        Log(LOGLEVEL_ERROR, "%s - segment load error, packet index %d does not equal expected value of %d with a total packet count of: %d", __FUNCTION__, loadedPacketIndex, i, m_currentPacketIndex);
+      m_packetBuffer.emplace_back(newPacket);
+    }
+
+    m_currentPacketIndex = packetCount;
+    m_persisted = true;
+    m_completed = true;
+
+    m_loaded = true;
+  }
+}
+
+int TimeshiftSegment::LoadPacket(std::shared_ptr<DemuxPacket>& packet)
+{
+  //Checksum
+  int packetIndex;
+  m_fileHandle.Read(&packetIndex, sizeof(packetIndex));
+
+  m_fileHandle.Read(&packet->iSize, sizeof(packet->iSize));
+  if (packet->iSize > 0)
+  {
+    packet->pData = new uint8_t[packet->iSize];
+    m_fileHandle.Read(packet->pData, packet->iSize);
+  }
+
+  m_fileHandle.Read(&packet->iStreamId, sizeof(packet->iStreamId));
+  m_fileHandle.Read(&packet->demuxerId, sizeof(packet->demuxerId));
+  m_fileHandle.Read(&packet->iGroupId, sizeof(packet->iGroupId));
+
+  m_fileHandle.Read(&packet->iSideDataElems, sizeof(packet->iSideDataElems));
+  if (packet->iSideDataElems > 0)
+  {
+    AVPacket avPacket;
+    av_init_packet(&avPacket);
+    enum AVPacketSideDataType type;
+    int size;
+    for (int i = 0; i < packet->iSideDataElems; i++)
+    {
+      m_fileHandle.Read(&type, sizeof(type));
+      m_fileHandle.Read(&size, sizeof(size));
+
+      uint8_t* data = av_packet_new_side_data(&avPacket, type, size);
+      m_fileHandle.Read(data, size);
+    }
+
+    packet->pSideData = avPacket.side_data;
+  }
+
+  m_fileHandle.Read(&packet->pts, sizeof(packet->pts));
+  m_fileHandle.Read(&packet->dts, sizeof(packet->dts));
+  m_fileHandle.Read(&packet->duration, sizeof(packet->duration));
+  m_fileHandle.Read(&packet->recoveryPoint, sizeof(packet->recoveryPoint));
+
+  bool hasCryptoInfo;
+  m_fileHandle.Read(&hasCryptoInfo, sizeof(hasCryptoInfo));
+  if (hasCryptoInfo)
+  {
+    int numSubSamples;
+    m_fileHandle.Read(&numSubSamples, sizeof(numSubSamples));
+
+    packet->cryptoInfo = std::make_shared<DemuxCryptoInfo>(numSubSamples);
+    m_fileHandle.Read(&packet->cryptoInfo->flags, sizeof(packet->cryptoInfo->flags));
+    if (numSubSamples > 0)
+    {
+      m_fileHandle.Read(packet->cryptoInfo->clearBytes, sizeof(uint16_t) * numSubSamples);
+      m_fileHandle.Read(packet->cryptoInfo->cipherBytes, sizeof(uint32_t) * numSubSamples);
+    }
+    m_fileHandle.Read(packet->cryptoInfo->iv, sizeof(uint8_t) * 16);
+    m_fileHandle.Read(packet->cryptoInfo->kid, sizeof(uint8_t) * 16);
+  }
+
+  return packetIndex;
+}
+
+int TimeshiftSegment::GetPacketCount()
+{
+  std::lock_guard<std::mutex> lock(m_mutex);
+  return m_currentPacketIndex;
+}
+
+void TimeshiftSegment::MarkAsComplete()
+{
+  std::lock_guard<std::mutex> lock(m_mutex);
+
+  if (m_fileHandle.IsOpen())
+  {
+    m_fileHandle.Seek(0);
+    m_fileHandle.Write(&m_currentPacketIndex, sizeof(m_currentPacketIndex));
+  }
+
+  m_completed = true;
+  m_fileHandle.Close();
+  m_persisted = true;
+}
+
+void TimeshiftSegment::ClearPackets()
+{
+  std::lock_guard<std::mutex> lock(m_mutex);
+
+  int m_readPacketIndex = 0;
+
+  for (auto& demuxPacket : m_packetBuffer)
+  {
+    delete[] demuxPacket->pData;
+    FreeSideData(demuxPacket);
+  }
+
+  m_packetBuffer.clear();
+  m_loaded = false;
+}
+
+bool TimeshiftSegment::ReadAllPackets()
+{
+  std::lock_guard<std::mutex> lock(m_mutex);
+  return m_completed && m_readPacketIndex == m_packetBuffer.size();
+}
+
+bool TimeshiftSegment::HasPacketAvailable()
+{
+  std::lock_guard<std::mutex> lock(m_mutex);
+  return m_readPacketIndex != m_packetBuffer.size();
+}
+
+void TimeshiftSegment::SetNextSegment(std::shared_ptr<TimeshiftSegment> nextSegment)
+{
+  std::lock_guard<std::mutex> lock(m_mutex);
+  m_nextSegment = nextSegment;
+}
+
+std::shared_ptr<TimeshiftSegment> TimeshiftSegment::GetNextSegment()
+{
+  std::lock_guard<std::mutex> lock(m_mutex);
+  return m_nextSegment;
+}
+
+void TimeshiftSegment::ResetReadIndex()
+{
+  std::lock_guard<std::mutex> lock(m_mutex);
+  m_readPacketIndex = 0;
+}
+
+int TimeshiftSegment::GetReadIndex()
+{
+  std::lock_guard<std::mutex> lock(m_mutex);
+  return m_readPacketIndex;
+}
+
+int TimeshiftSegment::GetSegmentId()
+{
+  std::lock_guard<std::mutex> lock(m_mutex);
+  return m_segmentId;
+}
+
+DemuxPacket* TimeshiftSegment::ReadPacket()
+{
+  DemuxPacket* packet = nullptr;
+
+  std::lock_guard<std::mutex> lock(m_mutex);
+
+  if (m_readPacketIndex != m_packetBuffer.size())
+  {
+    std::shared_ptr<DemuxPacket>& nextPacket = m_packetBuffer[m_readPacketIndex++];
+
+    packet = m_demuxPacketManager->AllocateDemuxPacketFromInputStreamAPI(nextPacket->iSize);
+
+    CopyPacket(nextPacket.get(), packet, false);
+  }
+  else
+  {
+    packet = m_demuxPacketManager->AllocateDemuxPacketFromInputStreamAPI(0);
+  }
+
+  return packet;
+}
+
+bool TimeshiftSegment::Seek(double timeMs)
+{
+  int seekSeconds = timeMs / 1000;
+  std::lock_guard<std::mutex> lock(m_mutex);
+
+  auto seekPacketIndex = m_packetTimeIndexMap.upper_bound(seekSeconds);
+  // Upper bound gets the packet after the one we want
+  if (seekPacketIndex != m_packetTimeIndexMap.begin())
+    --seekPacketIndex;
+
+  if (seekPacketIndex != m_packetTimeIndexMap.end())
+  {
+    m_readPacketIndex = seekPacketIndex->second;
+
+    auto it = m_packetTimeIndexMap.begin();
+    int timeIndexStart = it->first;
+    auto it2 = m_packetTimeIndexMap.rbegin();
+    int timeIndexEnd = it2->first;
+    Log(LOGLEVEL_INFO, "%s - Seek segment packet - segment ID: %d, packet index: %d, seek seconds: %d, segmetn start seconds: %d, segment end seconds: %d", __FUNCTION__, m_segmentId, m_readPacketIndex, seekSeconds, timeIndexStart, timeIndexEnd);
+
+    return true;
+  }
+
+  return false;
+}
+
+/* For refernce */
+
+// typedef struct DemuxPacket
+// {
+//   DemuxPacket() = default;
+
+//   uint8_t *pData = nullptr;
+//   int iSize = 0;
+//   int iStreamId = -1;
+//   int64_t demuxerId = -1; // id of the demuxer that created the packet
+//   int iGroupId = -1; // the group this data belongs to, used to group data from different streams together
+
+//   void *pSideData = nullptr;
+//   int iSideDataElems = 0;
+
+//   double pts = DVD_NOPTS_VALUE;
+//   double dts = DVD_NOPTS_VALUE;
+//   double duration = 0; // duration in DVD_TIME_BASE if available
+//   int dispTime = 0;
+//   bool recoveryPoint = false;
+
+//   std::shared_ptr<DemuxCryptoInfo> cryptoInfo;
+// } DemuxPacket;
+
+// typedef struct AVPacketSideData {
+//     uint8_t *data;
+//     int      size;
+//     enum AVPacketSideDataType type;
+// } AVPacketSideData;
+
+  // explicit DemuxCryptoInfo(const unsigned int numSubs)
+  //   : numSubSamples(numSubs)
+  //   , flags(0)
+  //   , clearBytes(new uint16_t[numSubs])
+  //   , cipherBytes(new uint32_t[numSubs])
+  // {};
+
+  // ~DemuxCryptoInfo()
+  // {
+  //   delete[] clearBytes;
+  //   delete[] cipherBytes;
+  // }
+
+  // uint16_t numSubSamples; //number of subsamples
+  // uint16_t flags; //flags for later use
+
+  // uint16_t *clearBytes; // numSubSamples uint16_t's wich define the size of clear size of a subsample
+  // uint32_t *cipherBytes; // numSubSamples uint32_t's wich define the size of cipher size of a subsample
+
+  // uint8_t iv[16]; // initialization vector
+  // uint8_t kid[16]; // key id

--- a/src/stream/TimeshiftSegment.h
+++ b/src/stream/TimeshiftSegment.h
@@ -1,0 +1,87 @@
+/*
+ *  Copyright (C) 2005-2020 Team Kodi
+ *  https://kodi.tv
+ *
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *  See LICENSE.md for more information.
+ */
+
+#pragma once
+
+#include "IManageDemuxPacket.h"
+
+#include <chrono>
+#include <map>
+#include <memory>
+#include <mutex>
+#include <vector>
+
+#include <kodi/Filesystem.h>
+
+#include <kodi/addon-instance/Inputstream.h>
+
+namespace ffmpegdirect
+{
+
+static const std::string DEFAULT_TIMESHIFT_BUFFER_PATH = "special://userdata/addon_data/inputstream.ffmpegdirect/timeshift";
+
+class TimeshiftSegment
+{
+public:
+  TimeshiftSegment(IManageDemuxPacket* demuxPacketManager, const std::string& streamId, int segmentId, const std::string& timeshiftBufferPath);
+  ~TimeshiftSegment();
+
+  void AddPacket(DemuxPacket* packet);
+  DemuxPacket* ReadPacket();
+  bool Seek(double timeMs);
+
+  int GetPacketCount();
+  void MarkAsComplete();
+  bool HasPacketAvailable();
+  bool ReadAllPackets();
+  void SetNextSegment(std::shared_ptr<TimeshiftSegment> nextSegment);
+  std::shared_ptr<TimeshiftSegment> GetNextSegment();
+  void ResetReadIndex();
+  int GetReadIndex();
+  int GetSegmentId();
+  void ClearPackets();
+  void ForceLoadSegment();
+  void LoadSegment();
+
+protected:
+  IManageDemuxPacket* m_demuxPacketManager;
+
+private:
+  void CopyPacket(DemuxPacket* sourcePacket, DemuxPacket* newPacket, bool allocateData);
+  void CopySideData(DemuxPacket *sourcePacket, DemuxPacket* newPacket);
+  void FreeSideData(std::shared_ptr<DemuxPacket>& packet);
+  void WritePacket(std::shared_ptr<DemuxPacket>& packet);
+  int LoadPacket(std::shared_ptr<DemuxPacket>& packet);
+
+  std::shared_ptr<TimeshiftSegment> m_nextSegment;
+
+  int32_t m_currentPacketIndex = 0;
+  int m_readPacketIndex = 0;
+  int m_lastPacketSecondsSinceStart = 0;
+
+  std::vector<std::shared_ptr<DemuxPacket>> m_packetBuffer;
+  std::map<int, int> m_packetTimeIndexMap;
+
+  bool m_completed = false;
+  bool m_persisted = false;
+  bool m_loaded = true;
+  bool m_persistSegments = true;
+
+  int m_segmentId;
+
+  std::string m_streamId;
+  std::string m_segmentFilename;
+
+  kodi::vfs::CFile m_fileHandle;
+
+  std::string m_timeshiftSegmentFilePath;
+
+  std::mutex m_mutex;
+};
+
+} //namespace ffmpegdirect

--- a/src/stream/TimeshiftStream.cpp
+++ b/src/stream/TimeshiftStream.cpp
@@ -1,0 +1,172 @@
+/*
+ *  Copyright (C) 2005-2020 Team Kodi
+ *  https://kodi.tv
+ *
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *  See LICENSE.md for more information.
+ */
+
+#include "TimeshiftStream.h"
+
+#include "threads/SingleLock.h"
+#include "../utils/Log.h"
+
+#ifndef __STDC_CONSTANT_MACROS
+#define __STDC_CONSTANT_MACROS
+#endif
+#ifndef __STDC_LIMIT_MACROS
+#define __STDC_LIMIT_MACROS
+#endif
+#ifdef TARGET_POSIX
+#include <stdint.h>
+#endif
+
+using namespace ffmpegdirect;
+
+TimeshiftStream::TimeshiftStream(IManageDemuxPacket* demuxPacketManager,
+                                 const Properties props,
+                                 const HttpProxy& httpProxy)
+  : FFmpegStream(demuxPacketManager, props.m_openMode, httpProxy)
+{
+  std::random_device randomDevice; //Will be used to obtain a seed for the random number engine
+  m_randomGenerator = std::mt19937(randomDevice()); //Standard mersenne_twister_engine seeded with randomDevice()
+  m_randomDistribution = std::uniform_int_distribution<>(0, 1000);
+}
+
+TimeshiftStream::~TimeshiftStream()
+{
+
+}
+
+bool TimeshiftStream::Open(const std::string& streamUrl, const std::string& mimeType, bool isRealTimeStream, const std::string& programProperty)
+{
+  if (FFmpegStream::Open(streamUrl, mimeType, isRealTimeStream, programProperty))
+  {
+    Start();
+
+    return true;
+  }
+
+  return false;
+}
+
+DemuxPacket* TimeshiftStream::DemuxRead()
+{
+  std::unique_lock<std::mutex> lock(m_mutex);
+  m_condition.wait_for(lock, std::chrono::milliseconds(10), [&] { return m_timeshiftBuffer.HasPacketAvailable(); });
+
+  return m_timeshiftBuffer.ReadPacket();
+}
+
+bool TimeshiftStream::Start()
+{
+  if (m_running)
+    return true;
+
+  Log(LOGLEVEL_DEBUG, "%s - Timeshift: started", __FUNCTION__);
+  m_timeshiftBuffer.Start(GenerateStreamId(m_streamUrl));
+  m_running = true;
+  m_inputThread = std::thread([&] { DoReadWrite(); });
+
+  return true;
+}
+
+void TimeshiftStream::Close()
+{
+  m_running = false;
+  if (m_inputThread.joinable())
+    m_inputThread.join();
+
+  FFmpegStream::Close();
+
+  Log(LOGLEVEL_DEBUG, "%s - Timeshift: closed", __FUNCTION__);
+}
+
+void TimeshiftStream::DoReadWrite()
+{
+  Log(LOGLEVEL_DEBUG, "%s - Timeshift: started", __FUNCTION__);
+  while (m_running)
+  {
+    DemuxPacket* pPacket = FFmpegStream::DemuxRead();
+    if (pPacket)
+    {
+      std::lock_guard<std::mutex> lock(m_mutex);
+      m_timeshiftBuffer.AddPacket(pPacket);
+    }
+
+    m_condition.notify_one();
+  }
+  Log(LOGLEVEL_DEBUG, "%s - Timeshift: stopped", __FUNCTION__);
+  return;
+}
+
+void TimeshiftStream::GetCapabilities(INPUTSTREAM_CAPABILITIES &caps)
+{
+  caps.m_mask = INPUTSTREAM_CAPABILITIES::SUPPORTS_IDEMUX |
+    INPUTSTREAM_CAPABILITIES::SUPPORTS_ITIME |
+    INPUTSTREAM_CAPABILITIES::SUPPORTS_SEEK |
+    INPUTSTREAM_CAPABILITIES::SUPPORTS_PAUSE;
+}
+
+int64_t TimeshiftStream::LengthStream()
+{
+  int64_t length = -1;
+  INPUTSTREAM_TIMES times = {0};
+  if (GetTimes(times) && times.ptsEnd >= times.ptsBegin)
+    length = static_cast<int64_t>(times.ptsEnd - times.ptsBegin);
+
+  return length;
+}
+
+bool TimeshiftStream::GetTimes(INPUTSTREAM_TIMES& times)
+{
+  times = {0};
+
+  times.startTime = m_timeshiftBuffer.GetStartTimeSecs();
+  times.ptsStart = 0;
+  times.ptsBegin = m_timeshiftBuffer.GetEarliestSegmentMillisecondsSinceStart() * 1000;
+  times.ptsEnd = m_timeshiftBuffer.GetMillisecondsSinceStart() * 1000;
+
+  return true;
+}
+
+bool TimeshiftStream::IsRealTimeStream()
+{
+  return true;
+}
+
+bool TimeshiftStream::DemuxSeekTime(double timeMs, bool backwards, double& startpts)
+{
+  if (timeMs < 0)
+    return false;
+
+  return m_timeshiftBuffer.Seek(timeMs);
+}
+
+void TimeshiftStream::DemuxSetSpeed(int speed)
+{
+  Log(LOGLEVEL_DEBUG, "%s - DemuxSetSpeed %d", __FUNCTION__, speed);
+
+  if (m_demuxSpeed == DVD_PLAYSPEED_PAUSE && speed != DVD_PLAYSPEED_PAUSE)
+    m_timeshiftBuffer.SetPaused(false); // Resume Playback
+  else if (m_demuxSpeed != DVD_PLAYSPEED_PAUSE && speed == DVD_PLAYSPEED_PAUSE)
+    m_timeshiftBuffer.SetPaused(true); // Pause Playback
+
+  m_demuxSpeed = speed;
+}
+
+std::string TimeshiftStream::GenerateStreamId(const std::string streamUrl)
+{
+  std::string sourceString;
+  sourceString.append(streamUrl);
+
+  sourceString += "-" + std::to_string(m_randomDistribution(m_randomGenerator));
+
+  const char* calcString = sourceString.c_str();
+  int iId = 0;
+  int c;
+  while ((c = *calcString++))
+    iId = ((iId << 5) + iId) + c; /* iId * 33 + c */
+
+  return std::to_string(abs(iId));
+}

--- a/src/stream/TimeshiftStream.h
+++ b/src/stream/TimeshiftStream.h
@@ -1,0 +1,66 @@
+/*
+ *  Copyright (C) 2005-2020 Team Kodi
+ *  https://kodi.tv
+ *
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *  See LICENSE.md for more information.
+ */
+
+#pragma once
+
+#include "../utils/HttpProxy.h"
+#include "../utils/Properties.h"
+#include "FFmpegStream.h"
+#include "TimeshiftBuffer.h"
+
+#include <atomic>
+#include <condition_variable>
+#include <mutex>
+#include <random>
+#include <string>
+#include <thread>
+
+namespace ffmpegdirect
+{
+
+class TimeshiftStream
+  : public FFmpegStream
+{
+public:
+  TimeshiftStream(IManageDemuxPacket* demuxPacketManager,
+                  const Properties props,
+                  const HttpProxy& httpProxy);
+  ~TimeshiftStream();
+
+  virtual bool Open(const std::string& streamUrl, const std::string& mimeType, bool isRealTimeStream, const std::string& programProperty) override;
+  virtual void Close() override;
+  virtual void GetCapabilities(INPUTSTREAM_CAPABILITIES& caps) override;
+
+  virtual DemuxPacket* DemuxRead() override;
+  virtual bool DemuxSeekTime(double time, bool backwards, double& startpts) override;
+  virtual void DemuxSetSpeed(int speed) override;
+
+  virtual bool GetTimes(INPUTSTREAM_TIMES& times) override;
+
+  virtual int64_t LengthStream() override;
+  virtual bool IsRealTimeStream() override;
+
+private:
+  void DoReadWrite();
+  bool Start();
+  std::string GenerateStreamId(const std::string streamUrl);
+
+  std::mt19937 m_randomGenerator;
+  std::uniform_int_distribution<> m_randomDistribution;
+
+  std::atomic<bool> m_running = {false};
+  std::thread m_inputThread;
+  std::condition_variable m_condition;
+  std::mutex m_mutex;
+
+  double m_demuxSpeed = DVD_PLAYSPEED_NORMAL;
+
+  TimeshiftBuffer m_timeshiftBuffer{m_demuxPacketManager};
+};
+
+} //namespace ffmpegdirect

--- a/src/utils/FilenameUtils.cpp
+++ b/src/utils/FilenameUtils.cpp
@@ -10,7 +10,7 @@
 
 #include <p8-platform/util/StringUtils.h>
 
-using namespace ffmpegdirect::utils;
+using namespace ffmpegdirect;
 
 std::string FilenameUtils::MakeLegalFileName(const std::string &strFile, int LegalType)
 {

--- a/src/utils/FilenameUtils.h
+++ b/src/utils/FilenameUtils.h
@@ -12,22 +12,19 @@
 
 namespace ffmpegdirect
 {
-  namespace utils
-  {
-    static const int LEGAL_NONE = 0;
-    static const int LEGAL_WIN32_COMPAT = 1;
-    static const int LEGAL_FATX = 2;
+  static const int LEGAL_NONE = 0;
+  static const int LEGAL_WIN32_COMPAT = 1;
+  static const int LEGAL_FATX = 2;
 
-    class FilenameUtils
-    {
-    public:
+  class FilenameUtils
+  {
+  public:
 #ifdef TARGET_WINDOWS
-      static std::string MakeLegalFileName(const std::string &strFile, int LegalType=LEGAL_WIN32_COMPAT);
-      static std::string MakeLegalPath(const std::string &strPath, int LegalType=LEGAL_WIN32_COMPAT);
+    static std::string MakeLegalFileName(const std::string &strFile, int LegalType=LEGAL_WIN32_COMPAT);
+    static std::string MakeLegalPath(const std::string &strPath, int LegalType=LEGAL_WIN32_COMPAT);
 #else
-      static std::string MakeLegalFileName(const std::string &strFile, int LegalType=LEGAL_NONE);
-      static std::string MakeLegalPath(const std::string &strPath, int LegalType=LEGAL_NONE);
+    static std::string MakeLegalFileName(const std::string &strFile, int LegalType=LEGAL_NONE);
+    static std::string MakeLegalPath(const std::string &strPath, int LegalType=LEGAL_NONE);
 #endif      
-    };
-  } //namespace utils
+  };
 } //namespace ffmpegdirect

--- a/src/utils/HttpProxy.h
+++ b/src/utils/HttpProxy.h
@@ -12,32 +12,29 @@
 
 namespace ffmpegdirect
 {
-  namespace utils
+  class HttpProxy
   {
-    class HttpProxy
-    {
-    public:
-      HttpProxy() {};
-      HttpProxy(const std::string& host, uint16_t port, const std::string& user, const std::string& password)
-        : m_host(host), m_port(port), m_user(user), m_password(password) {};
+  public:
+    HttpProxy() {};
+    HttpProxy(const std::string& host, uint16_t port, const std::string& user, const std::string& password)
+      : m_host(host), m_port(port), m_user(user), m_password(password) {};
 
-      const std::string& GetProxyHost() const { return m_host; }
-      void SetProxyHost(const std::string& value) { m_host = value; }
+    const std::string& GetProxyHost() const { return m_host; }
+    void SetProxyHost(const std::string& value) { m_host = value; }
 
-      uint16_t GetProxyPort() const { return m_port; }
-      void SetProxyPort(uint16_t value) { m_port = value; }
+    uint16_t GetProxyPort() const { return m_port; }
+    void SetProxyPort(uint16_t value) { m_port = value; }
 
-      const std::string& GetProxyUser() const { return m_user; }
-      void SetProxyUser(const std::string& value) { m_user = value; }
+    const std::string& GetProxyUser() const { return m_user; }
+    void SetProxyUser(const std::string& value) { m_user = value; }
 
-      const std::string& GetProxyPassword() const { return m_password; }
-      void SetProxyPassword(const std::string& value) { m_password = value; }
+    const std::string& GetProxyPassword() const { return m_password; }
+    void SetProxyPassword(const std::string& value) { m_password = value; }
 
-    private:
-      std::string m_host;
-      uint16_t m_port;
-      std::string m_user;
-      std::string m_password;
-    };
-  } //namespace utils
+  private:
+    std::string m_host;
+    uint16_t m_port;
+    std::string m_user;
+    std::string m_password;
+  };
 } //namespace ffmpegdirect

--- a/src/utils/Properties.h
+++ b/src/utils/Properties.h
@@ -1,0 +1,53 @@
+/*
+ *  Copyright (C) 2005-2020 Team Kodi
+ *  https://kodi.tv
+ *
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *  See LICENSE.md for more information.
+ */
+
+#pragma once
+
+#include <string>
+
+namespace ffmpegdirect
+{
+  enum class StreamMode
+    : int // same type as addon settings
+  {
+    NONE = 0,
+    CATCHUP
+  };
+
+  enum class OpenMode
+    : int // same type as addon settings
+  {
+    DEFAULT = 0,
+    FFMPEG,
+    CURL
+  };
+
+  struct Properties
+  {
+    std::string m_programProperty;
+    bool m_isRealTimeStream;
+    StreamMode m_streamMode = StreamMode::NONE;
+    OpenMode m_openMode = OpenMode::DEFAULT;
+    std::string m_manifestType;
+    std::string m_defaultUrl;
+
+    bool m_playbackAsLive = false;
+    time_t m_programmeStartTime = 0;
+    time_t m_programmeEndTime = 0;
+    std::string m_catchupUrlFormatString;
+    std::string m_catchupUrlNearLiveFormatString;
+    time_t m_catchupBufferStartTime = 0;
+    time_t m_catchupBufferEndTime = 0;
+    long long m_catchupBufferOffset = 0;
+    bool m_catchupTerminates = false;
+    int m_catchupGranularity = 1;
+    int m_timezoneShiftSecs = 0;
+    int m_defaultProgrammeDurationSecs = 4 * 60 * 60; //Four hours
+    std::string m_programmeCatchupId;      
+  };
+} //namespace ffmpegdirect

--- a/src/utils/Properties.h
+++ b/src/utils/Properties.h
@@ -16,7 +16,8 @@ namespace ffmpegdirect
     : int // same type as addon settings
   {
     NONE = 0,
-    CATCHUP
+    CATCHUP,
+    TIMESHIFT
   };
 
   enum class OpenMode


### PR DESCRIPTION
v1.12.0
- Added: Support seeking for VOD streams or regular file playback
- Fixed: Update HLS iformat name and remove hls workaround which is fixed in current FFmpeg
- Added: Timeshift for live streams (experimental)
- Added: Add support for Kodi user-agent and cookies when calling FFmpeg directly
- Added: Support multiple occurrences of year, month and day in catchup format specifiers
- Added: Add option to turn FFmpeg logging on/off