### PR TITLE
[ubuntu packaging]: use kodi's own ffmpeg

### DIFF
--- a/FindBZip2.cmake
+++ b/FindBZip2.cmake
@@ -5,7 +5,6 @@
 # BZIP2_INCLUDE_DIRS - the bzip2 include directory
 # BZIP2_LIBRARIES - The bzip2 libraries
 
-include(FindPkgConfig)
 find_package(PkgConfig)
 
 if(PKG_CONFIG_FOUND)
@@ -16,8 +15,7 @@ find_path(BZIP2_INCLUDE_DIRS bzlib.h PATHS ${PC_BZIP2_INCLUDEDIR})
 find_library(BZIP2_LIBRARIES bz2 PATHS ${PC_BZIP2_LIBDIR})
 
 include(FindPackageHandleStandardArgs)
-find_package_handle_standard_args(Gmp DEFAULT_MSG BZIP2_INCLUDE_DIRS BZIP2_LIBRARIES)
+find_package_handle_standard_args(BZip2 DEFAULT_MSG BZIP2_INCLUDE_DIRS BZIP2_LIBRARIES)
 
-mark_as_advanced(BZIP2_INCLUDE_DIRS BZIP2_LIBRARIES BZIP2_DEFINITIONS)
-#mark_as_advanced(BZIP2_DEFINITIONS)
+mark_as_advanced(BZIP2_INCLUDE_DIRS BZIP2_LIBRARIES)
 

--- a/debian/control
+++ b/debian/control
@@ -1,9 +1,8 @@
 Source: kodi-inputstream-ffmpegdirect
 Priority: extra
 Maintainer: Ross Nicholson <phunkyfish@gmail.com>
-Build-Depends: debhelper (>= 9.0.0), cmake, kodi-addon-dev,
-               libavutil-dev (>= 4.2.2), libavcodec-dev (>= 4.2.2), libavformat-dev (>= 4.2.2), libavfilter-dev (>= 4.2.2),
-               libbz2-dev, libp8-platform-dev, libssl-dev, libz3-dev, pkg-config, yasm, zlib1g-dev
+Build-Depends: debhelper (>= 10.0.0), cmake, kodi-addon-dev, kodi-ffmpeg-dev,
+               libbz2-dev, libp8-platform-dev, libz3-dev, pkg-config, yasm, zlib1g-dev
 Standards-Version: 4.0.0
 Section: libs
 Homepage: <https://kodi.tv>

--- a/debian/rules
+++ b/debian/rules
@@ -9,9 +9,12 @@
 # Uncomment this to turn on verbose mode.
 #export DH_VERBOSE=1
 
+# strip -Bsymbolic-functions, it breaks linking with ffmpeg
+export DEB_LDFLAGS_MAINT_STRIP = -Wl,-Bsymbolic-functions
+
 %:
 	dh $@ --parallel
 
 override_dh_auto_configure:
-	dh_auto_configure -- -DBUILD_SHARED_LIBS=1 -DUSE_LTO=1
+	dh_auto_configure -- -DBUILD_SHARED_LIBS=1 -DUSE_LTO=1 -DCMAKE_PREFIX_PATH=/usr/lib/${DEB_HOST_MULTIARCH}/kodi/ffmpeg
 


### PR DESCRIPTION
This fixes the crashes reported for the ubuntu (nightly) PPA builds.

The kodi package now provides a kodi-ffmpeg-dev package containing our own ffmpeg libs. We use that instead of system ffmpeg libs to get rid of symbol issues with different ffmpeg between inputstream.ffmpeg and kodi at runtime.

Tested on ubuntu 18.04: I can successfully timeshift with iptv simple.

I've also included a cmake warning fix that's independent of that actual fix, let me know if you want a seperate PR.

@notspiff fyi, might be useful for other addons that need ffmpeg
