### PR TITLE
Use kodi's own FFmpeg for ubuntu packaging release

### DIFF
--- a/inputstream.ffmpegdirect/addon.xml.in
+++ b/inputstream.ffmpegdirect/addon.xml.in
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <addon
   id="inputstream.ffmpegdirect"
-  version="1.14.3"
+  version="1.14.4"
   name="Inputstream FFmpeg Direct"
   provider-name="Ross Nicholson">
   <requires>@ADDON_DEPENDS@</requires>
@@ -24,6 +24,9 @@
       <fanart>fanart.jpg</fanart>
     </assets>
     <news>
+v1.14.4
+- Fixed: Use kodi's own FFmpeg for ubuntu packaging
+
 v1.14.3
 - Update: Use FFmpeg 4.3
 

--- a/inputstream.ffmpegdirect/changelog.txt
+++ b/inputstream.ffmpegdirect/changelog.txt
@@ -1,3 +1,6 @@
+v1.14.4
+- Fixed: Use kodi's own FFmpeg for ubuntu packaging
+
 v1.14.3
 - Update: Use FFmpeg 4.3
 


### PR DESCRIPTION
v1.14.4
- Fixed: Use kodi's own FFmpeg for ubuntu packaging