### PR TITLE
Lean mode

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -35,6 +35,7 @@ set(CATCHUP_SOURCES src/StreamManager.cpp
                     src/stream/url/URL.cpp
                     src/stream/url/UrlOptions.cpp
                     src/stream/url/Variant.cpp
+                    src/utils/DiskUtils.cpp
                     src/utils/FilenameUtils.cpp)
 
 set(CATCHUP_HEADERS src/StreamManager.h
@@ -64,6 +65,7 @@ set(CATCHUP_HEADERS src/StreamManager.h
                     src/stream/TimeshiftSegment.h
                     src/stream/TimeshiftStream.h
                     src/utils/HttpProxy.h
+                    src/utils/DiskUtils.h
                     src/utils/FilenameUtils.h
                     src/utils/Log.h
                     src/utils/Properties.h

--- a/README.md
+++ b/README.md
@@ -82,6 +82,8 @@ This category contains the advanced settings for the addon.
 * **Allow FFmpeg logging**: If enabled the addon will log any FFmpeg logging to the Kodi log.
 * **Probe for FPS**: Probe for frames per second. Default enabled. If disabled the value returned by the codec will be used.
 * **Enable teletext**: Allow teletext. Default enabled.
+* **Use fast open for streams using a manifest file**: Streams which have a manifest file (e.g. HLD/DASH/Smooth Streaming) can be opened more quickly with FFmpeg with this option enabled.
+* **For catchup streams report stream is not realtime**: For certain catchup streams such as HLS reporting that a live stream is not live can improve stream open times. If testing this option works for a catchup stream/provider, then add a `#KODIPROP=inputstream.ffmpegdirect.is_realtime_stream=false` to the M3U entry in question. This setting should not be left enabled for all streams.
 
 ## Using the addon
 

--- a/inputstream.ffmpegdirect/addon.xml.in
+++ b/inputstream.ffmpegdirect/addon.xml.in
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <addon
   id="inputstream.ffmpegdirect"
-  version="1.14.5"
+  version="1.15.0"
   name="Inputstream FFmpeg Direct"
   provider-name="Ross Nicholson">
   <requires>@ADDON_DEPENDS@</requires>
@@ -24,6 +24,20 @@
       <fanart>fanart.jpg</fanart>
     </assets>
     <news>
+v1.15.0
+- Added: Add fast open for manifest stream and test setting for realtime off
+- Fixed: Honour realtime stream property
+- Fixed: Fix using prev button to seek back to start of stream
+- Fixed: Ensure no slash at end of timeshift buffer path
+- Fixed: Make sure write segment file is closed when buffer is destroyed
+- Fixed: Use overwrite when opening files for write for compatibility with SMB on Android
+- Fixed: Don't start timeshift and exit if index file cannot be created
+- Update: If any timeshift file cannot be created log free disk space
+- Fixed: Avoid crash for zero byte or partial timeshift segment files
+- Fixed: Only read ffmpeg logging setting on stream start
+- Update: Redact username and password for urls in log statements
+- Fixed: Only create timeshift directory if it does not exist
+
 v1.14.5
 - Fixed: Fix lintian spellings and mimetype log statement
 - Update: Readme

--- a/inputstream.ffmpegdirect/changelog.txt
+++ b/inputstream.ffmpegdirect/changelog.txt
@@ -1,3 +1,17 @@
+v1.15.0
+- Added: Add fast open for manifest stream and test setting for realtime off
+- Fixed: Honour realtime stream property
+- Fixed: Fix using prev button to seek back to start of stream
+- Fixed: Ensure no slash at end of timeshift buffer path
+- Fixed: Make sure write segment file is closed when buffer is destroyed
+- Fixed: Use overwrite when opening files for write for compatibility with SMB on Android
+- Fixed: Don't start timeshift and exit if index file cannot be created
+- Update: If any timeshift file cannot be created log free disk space
+- Fixed: Avoid crash for zero byte or partial timeshift segment files
+- Fixed: Only read ffmpeg logging setting on stream start
+- Update: Redact username and password for urls in log statements
+- Fixed: Only create timeshift directory if it does not exist
+
 v1.14.5
 - Fixed: Fix lintian spellings and mimetype log statement
 - Update: Readme

--- a/inputstream.ffmpegdirect/resources/language/resource.language.en_gb/strings.po
+++ b/inputstream.ffmpegdirect/resources/language/resource.language.en_gb/strings.po
@@ -115,7 +115,17 @@ msgctxt "#30044"
 msgid "Enable teletext"
 msgstr ""
 
-#empty strings from id 30045 to 30599
+#. help: Advanced - useFastOpemForManifestStreams
+msgctxt "#30045"
+msgid "Use fast open for streams using a manifest file"
+msgstr ""
+
+#. help: Advanced - forceRealtimeOffCatchup
+msgctxt "#30046"
+msgid "For catchup streams report stream is not realtime"
+msgstr ""
+
+#empty strings from id 30047 to 30599
 
 #. ############
 #. help info #
@@ -174,7 +184,7 @@ msgstr ""
 
 #. help: Timeshift - timeshiftEnableLimit
 msgctxt "#30622"
-msgid "Enable this option to limit the length of the timeshift buffer. If disabled the buffer will grow forever until playback is stopped. Reagrdless of this setting the buffer will also grow forever if paused."
+msgid "Enable this option to limit the length of the timeshift buffer. If disabled the buffer will grow forever until playback is stopped. Regardless of this setting the buffer will also grow forever if paused."
 msgstr ""
 
 #. help: Timeshift - timeshiftOnDiskLength
@@ -188,20 +198,30 @@ msgstr ""
 
 #. help-category: advanced
 msgctxt "#30640"
-msgid "Enable this option to limit the length of the timeshift buffer. If disabled the buffer will grow forever until playback is stopped. Reagrdless of this setting the buffer will also grow forever if paused."
+msgid "Advanced settings"
 msgstr ""
 
-#. help: Timeshift - allowFFmpegLogging
+#. help: Advanced - allowFFmpegLogging
 msgctxt "#30641"
 msgid "If enabled the addon will log any FFmpeg logging to the Kodi log."
 msgstr ""
 
-#. help: Timeshift - probeForFps
+#. help: Advanced - probeForFps
 msgctxt "#30642"
 msgid "Probe for frames per second. Default enabled. If disabled the value returned by the codec will be used."
 msgstr ""
 
-#. help: Timeshift - enableTeletext
+#. help: Advanced - enableTeletext
 msgctxt "#30643"
 msgid "Allow teletext. Default enabled."
+msgstr ""
+
+#. help: Advanced - useFastOpenForManifestStreams
+msgctxt "#30644"
+msgid "Streams which have a manifest file (e.g. HLD/DASH/Smooth Streaming) can be opened more quickly with FFmpeg with this option enabled."
+msgstr ""
+
+#. help: Advanced - forceRealtimeOffCatchup
+msgctxt "#30645"
+msgid "For certain catchup streams such as HLS reporting that a live stream is not live can improve stream open times. If testing this option works for a catchup stream/provider, then add a `#KODIPROP=inputstream.ffmpegdirect.is_realtime_stream=false` to the M3U entry in question. This setting should not be left enabled for all streams."
 msgstr ""

--- a/inputstream.ffmpegdirect/resources/settings.xml
+++ b/inputstream.ffmpegdirect/resources/settings.xml
@@ -130,6 +130,16 @@
           <default>true</default>
           <control type="toggle" />
         </setting>
+        <setting id="useFastOpenForManifestStreams" type="boolean" label="30045" help="30644">
+          <level>2</level>
+          <default>true</default>
+          <control type="toggle" />
+        </setting>
+        <setting id="forceRealtimeOffCatchup" type="boolean" label="30046" help="30645">
+          <level>2</level>
+          <default>false</default>
+          <control type="toggle" />
+        </setting>
       </group>
     </category>
   </section>

--- a/src/StreamManager.cpp
+++ b/src/StreamManager.cpp
@@ -202,7 +202,7 @@ bool InputStreamFFmpegDirect::Open(INPUTSTREAM& props)
   else if (properties.m_streamMode == StreamMode::TIMESHIFT)
     m_stream = std::make_shared<TimeshiftStream>(static_cast<IManageDemuxPacket*>(this), properties, httpProxy);
   else
-    m_stream = std::make_shared<FFmpegStream>(static_cast<IManageDemuxPacket*>(this), properties.m_openMode, httpProxy);
+    m_stream = std::make_shared<FFmpegStream>(static_cast<IManageDemuxPacket*>(this), properties, httpProxy);
 
   m_stream->SetVideoResolution(m_videoWidth, m_videoHeight);
 

--- a/src/stream/FFmpegCatchupStream.cpp
+++ b/src/stream/FFmpegCatchupStream.cpp
@@ -45,9 +45,9 @@ using namespace ffmpegdirect;
 ***********************************************************/
 
 FFmpegCatchupStream::FFmpegCatchupStream(IManageDemuxPacket* demuxPacketManager,
-                                         const Properties props,
+                                         const Properties& props,
                                          const HttpProxy& httpProxy)
-  : FFmpegStream(demuxPacketManager, props.m_openMode, std::make_shared<CurlCatchupInput>(), httpProxy),
+  : FFmpegStream(demuxPacketManager, props, std::make_shared<CurlCatchupInput>(), httpProxy),
     m_isOpeningStream(false), m_seekOffset(0),
     m_defaultUrl(props.m_defaultUrl), m_playbackAsLive(props.m_playbackAsLive),
     m_programmeStartTime(props.m_programmeStartTime), m_programmeEndTime(props.m_programmeEndTime),
@@ -368,6 +368,14 @@ void FFmpegCatchupStream::UpdateCurrentPTS()
   FFmpegStream::UpdateCurrentPTS();
   if (m_currentPts != DVD_NOPTS_VALUE)
     m_currentPts += m_seekOffset;
+}
+
+bool FFmpegCatchupStream::IsRealTimeStream()
+{
+  if (kodi::GetSettingBoolean("forceRealtimeOffCatchup"))
+    return false;
+
+  return m_isRealTimeStream && m_pFormatContext->duration <= 0;
 }
 
 namespace

--- a/src/stream/FFmpegCatchupStream.cpp
+++ b/src/stream/FFmpegCatchupStream.cpp
@@ -10,6 +10,7 @@
 
 #include "CurlCatchupInput.h"
 #include "threads/SingleLock.h"
+#include "url/URL.h"
 #include "../utils/Log.h"
 
 #ifdef TARGET_POSIX
@@ -458,7 +459,7 @@ std::string FormatDateTime(time_t dateTimeEpg, time_t duration, const std::strin
   FormatUtc("${offset}", dateTimeNow - dateTimeEpg, formattedUrl);
   FormatUnits(dateTimeNow - dateTimeEpg, "offset", formattedUrl);
 
-  Log(LOGLEVEL_DEBUG, "%s - \"%s\"", __FUNCTION__, formattedUrl.c_str());
+  Log(LOGLEVEL_DEBUG, "%s - \"%s\"", __FUNCTION__, CURL::GetRedacted(formattedUrl).c_str());
 
   return formattedUrl;
 }
@@ -488,7 +489,7 @@ std::string FFmpegCatchupStream::GetUpdatedCatchupUrl() const
     if (offset > (timeNow - m_defaultProgrammeDuration) && !m_catchupUrlNearLiveFormatString.empty())
       urlFormatString = m_catchupUrlNearLiveFormatString;
 
-    Log(LOGLEVEL_DEBUG, "%s - Offset Time - \"%lld\" - %s", __FUNCTION__, static_cast<long long>(offset), m_catchupUrlFormatString.c_str());
+    Log(LOGLEVEL_DEBUG, "%s - Offset Time - \"%lld\" - %s", __FUNCTION__, static_cast<long long>(offset), CURL::GetRedacted(m_catchupUrlFormatString).c_str());
 
     std::string catchupUrl = FormatDateTime(offset - m_timezoneShift, duration, urlFormatString);
 
@@ -498,11 +499,11 @@ std::string FFmpegCatchupStream::GetUpdatedCatchupUrl() const
 
     if (!catchupUrl.empty())
     {
-      Log(LOGLEVEL_DEBUG, "%s - Catchup URL: %s", __FUNCTION__, catchupUrl.c_str());
+      Log(LOGLEVEL_DEBUG, "%s - Catchup URL: %s", __FUNCTION__, CURL::GetRedacted(catchupUrl).c_str());
       return catchupUrl;
     }
   }
 
-  Log(LOGLEVEL_DEBUG, "%s - Default URL: %s", __FUNCTION__, m_defaultUrl.c_str());
+  Log(LOGLEVEL_DEBUG, "%s - Default URL: %s", __FUNCTION__, CURL::GetRedacted(m_defaultUrl).c_str());
   return m_defaultUrl;
 }

--- a/src/stream/FFmpegCatchupStream.h
+++ b/src/stream/FFmpegCatchupStream.h
@@ -22,7 +22,7 @@ class FFmpegCatchupStream : public FFmpegStream
 {
 public:
   FFmpegCatchupStream(IManageDemuxPacket* demuxPacketManager,
-                      const Properties props,
+                      const Properties& props,
                       const HttpProxy& httpProxy);
   ~FFmpegCatchupStream();
 
@@ -40,6 +40,7 @@ public:
   int64_t SeekCatchupStream(double timeMs, bool backwards);
   virtual int64_t LengthStream() override;
   virtual bool GetTimes(INPUTSTREAM_TIMES& times) override;
+  virtual bool IsRealTimeStream() override;
 
 protected:
   void UpdateCurrentPTS() override;

--- a/src/stream/FFmpegLog.h
+++ b/src/stream/FFmpegLog.h
@@ -27,9 +27,12 @@ class FFmpegLog
 {
 public:
   static void SetLogLevel(int level);
+  static void SetEnabled(bool enabled);
+  static bool GetEnabled();
   static int GetLogLevel();
-  static void ClearLogLevel();
-  int level;
+
+  static int level;
+  static bool enabled;
 };
 
 } //namespace ffmpegdirect

--- a/src/stream/FFmpegStream.cpp
+++ b/src/stream/FFmpegStream.cpp
@@ -154,7 +154,7 @@ bool FFmpegStream::Open(const std::string& streamUrl, const std::string& mimeTyp
   if (m_opened)
   {
     FFmpegLog::SetEnabled(true);
-    av_dump_format(m_pFormatContext, 0, streamUrl.c_str(), 0);
+    av_dump_format(m_pFormatContext, 0, CURL::GetRedacted(streamUrl).c_str(), 0);
   }
   FFmpegLog::SetEnabled(kodi::GetSettingBoolean("allowFFmpegLogging"));
 

--- a/src/stream/FFmpegStream.cpp
+++ b/src/stream/FFmpegStream.cpp
@@ -126,6 +126,7 @@ FFmpegStream::FFmpegStream(IManageDemuxPacket* demuxPacketManager, const Propert
   m_dtsAtDisplayTime = DVD_NOPTS_VALUE;
 
   FFmpegLog::SetLogLevel(AV_LOG_INFO);
+  FFmpegLog::SetEnabled(kodi::GetSettingBoolean("allowFFmpegLogging"));
   av_log_set_callback(ff_avutil_log);
 }
 
@@ -133,7 +134,6 @@ FFmpegStream::~FFmpegStream()
 {
   Dispose();
   ff_flush_avutil_log_buffers();
-  FFmpegLog::ClearLogLevel();
 }
 
 bool FFmpegStream::Open(const std::string& streamUrl, const std::string& mimeType, bool isRealTimeStream, const std::string& programProperty)
@@ -151,6 +151,12 @@ bool FFmpegStream::Open(const std::string& streamUrl, const std::string& mimeTyp
                                                ADDON_READ_CHUNKED);
 
   m_opened = Open(false);
+  if (m_opened)
+  {
+    FFmpegLog::SetEnabled(true);
+    av_dump_format(m_pFormatContext, 0, streamUrl.c_str(), 0);
+  }
+  FFmpegLog::SetEnabled(kodi::GetSettingBoolean("allowFFmpegLogging"));
 
   return m_opened;
 }

--- a/src/stream/FFmpegStream.h
+++ b/src/stream/FFmpegStream.h
@@ -60,8 +60,8 @@ class FFmpegStream
   : public BaseStream
 {
 public:
-  FFmpegStream(IManageDemuxPacket* demuxPacketManager, const OpenMode& openMode, const HttpProxy& httpProxy);
-  FFmpegStream(IManageDemuxPacket* demuxPacketManager, const OpenMode& openMode, std::shared_ptr<CurlInput> curlInput, const HttpProxy& httpProxy);
+  FFmpegStream(IManageDemuxPacket* demuxPacketManager, const Properties& props, const HttpProxy& httpProxy);
+  FFmpegStream(IManageDemuxPacket* demuxPacketManager, const Properties& props, std::shared_ptr<CurlInput> curlInput, const HttpProxy& httpProxy);
   ~FFmpegStream();
 
   virtual bool Open(const std::string& streamUrl, const std::string& mimeType, bool isRealTimeStream, const std::string& programProperty) override;
@@ -116,6 +116,7 @@ protected:
   bool m_demuxResetOpenSuccess = false;
   std::string m_streamUrl;
   int m_lastPacketResult;
+  bool m_isRealTimeStream;
 
 private:
   bool Open(bool fileinfo);
@@ -191,7 +192,7 @@ private:
 
   std::string m_mimeType;
   std::string m_programProperty;
-  bool m_isRealTimeStream;
+  std::string m_manifestType;
   bool m_opened;
 
   HttpProxy m_httpProxy;

--- a/src/stream/TimeshiftBuffer.cpp
+++ b/src/stream/TimeshiftBuffer.cpp
@@ -20,7 +20,15 @@ TimeshiftBuffer::TimeshiftBuffer(IManageDemuxPacket* demuxPacketManager)
 {
   m_timeshiftBufferPath = kodi::GetSettingString("timeshiftBufferPath");
   if (m_timeshiftBufferPath.empty())
+  {
     m_timeshiftBufferPath = DEFAULT_TIMESHIFT_BUFFER_PATH;
+  }
+  else
+  {
+    if (StringUtils::EndsWith(m_timeshiftBufferPath, "/") || StringUtils::EndsWith(m_timeshiftBufferPath, "\\"))
+      m_timeshiftBufferPath.pop_back();
+  }
+
   kodi::vfs::CreateDirectory(m_timeshiftBufferPath);
 
   if (!kodi::CheckSettingBoolean("timeshiftEnableLimit", m_enableOnDiskSegmentLimit))

--- a/src/stream/TimeshiftBuffer.cpp
+++ b/src/stream/TimeshiftBuffer.cpp
@@ -68,7 +68,9 @@ TimeshiftBuffer::~TimeshiftBuffer()
 void TimeshiftBuffer::Start(const std::string& streamId)
 {
   m_segmentIndexFilePath = m_timeshiftBufferPath + "/" + streamId + ".idx";
-  if (!m_segmentIndexFileHandle.OpenFileForWrite(m_segmentIndexFilePath))
+  // We need to pass the overwrite parameter as true as otherwise
+  // opening on SMB for write on android will fail.
+  if (!m_segmentIndexFileHandle.OpenFileForWrite(m_segmentIndexFilePath, true))
   {
     Log(LOGLEVEL_ERROR, "%s - Failed to open segment index file on disk: %s", __FUNCTION__, m_segmentIndexFilePath.c_str());
   }

--- a/src/stream/TimeshiftBuffer.cpp
+++ b/src/stream/TimeshiftBuffer.cpp
@@ -8,6 +8,7 @@
 
 #include "TimeshiftBuffer.h"
 
+#include "../utils/DiskUtils.h"
 #include "../utils/Log.h"
 
 #include <kodi/Filesystem.h>
@@ -72,7 +73,12 @@ bool TimeshiftBuffer::Start(const std::string& streamId)
   // opening on SMB for write on android will fail.
   if (!m_segmentIndexFileHandle.OpenFileForWrite(m_segmentIndexFilePath, true))
   {
-    Log(LOGLEVEL_ERROR, "%s - Failed to open segment index file on disk: %s", __FUNCTION__, m_segmentIndexFilePath.c_str());
+    uint64_t freeSpaceMB = 0;
+    if (DiskUtils::GetFreeDiskSpaceMB(m_timeshiftBufferPath, freeSpaceMB))
+      Log(LOGLEVEL_ERROR, "%s - Failed to open segment index file on disk: %s, disk free space (MB): %lld", __FUNCTION__, m_segmentIndexFilePath.c_str(), static_cast<long long>(freeSpaceMB));
+    else
+      Log(LOGLEVEL_ERROR, "%s - Failed to open segment index file on disk: %s, not possible to calculate free space", __FUNCTION__, m_segmentIndexFilePath.c_str());
+    return false;
   }
 
   m_streamId = streamId;

--- a/src/stream/TimeshiftBuffer.cpp
+++ b/src/stream/TimeshiftBuffer.cpp
@@ -30,7 +30,8 @@ TimeshiftBuffer::TimeshiftBuffer(IManageDemuxPacket* demuxPacketManager)
       m_timeshiftBufferPath.pop_back();
   }
 
-  kodi::vfs::CreateDirectory(m_timeshiftBufferPath);
+  if (!kodi::vfs::DirectoryExists(m_timeshiftBufferPath))
+    kodi::vfs::CreateDirectory(m_timeshiftBufferPath);
 
   if (!kodi::CheckSettingBoolean("timeshiftEnableLimit", m_enableOnDiskSegmentLimit))
     m_enableOnDiskSegmentLimit = true;

--- a/src/stream/TimeshiftBuffer.cpp
+++ b/src/stream/TimeshiftBuffer.cpp
@@ -50,6 +50,8 @@ TimeshiftBuffer::~TimeshiftBuffer()
 {
   if (!m_streamId.empty())
   {
+    //We need to make sure any filehandle is closed as you can't delete an open file on windows
+    m_writeSegment->MarkAsComplete();
     for (int segmentId = m_earliestOnDiskSegmentId; segmentId <= m_writeSegment->GetSegmentId(); segmentId++)
     {
       std::string segmentFilename = StringUtils::Format("%s-%08d.seg", m_streamId.c_str(), segmentId);

--- a/src/stream/TimeshiftBuffer.cpp
+++ b/src/stream/TimeshiftBuffer.cpp
@@ -210,6 +210,9 @@ bool TimeshiftBuffer::Seek(double timeMs)
   int seekSeconds = timeMs / 1000;
   std::lock_guard<std::mutex> lock(m_mutex);
 
+  if (seekSeconds < 0)
+      seekSeconds = m_minOnDiskSeekTimeIndex;
+
   if (seekSeconds >= m_minInMemorySeekTimeIndex)
   {
     auto seekSegmentIndex = m_segmentTimeIndexMap.upper_bound(seekSeconds);

--- a/src/stream/TimeshiftBuffer.cpp
+++ b/src/stream/TimeshiftBuffer.cpp
@@ -65,7 +65,7 @@ TimeshiftBuffer::~TimeshiftBuffer()
   kodi::vfs::DeleteFile(m_segmentIndexFilePath);
 }
 
-void TimeshiftBuffer::Start(const std::string& streamId)
+bool TimeshiftBuffer::Start(const std::string& streamId)
 {
   m_segmentIndexFilePath = m_timeshiftBufferPath + "/" + streamId + ".idx";
   // We need to pass the overwrite parameter as true as otherwise
@@ -86,6 +86,8 @@ void TimeshiftBuffer::Start(const std::string& streamId)
   m_currentSegmentIndex++;
   m_segmentTotalCount++;
   m_readSegment = m_writeSegment;
+
+  return true;
 }
 
 void TimeshiftBuffer::AddPacket(DemuxPacket* packet)

--- a/src/stream/TimeshiftBuffer.cpp
+++ b/src/stream/TimeshiftBuffer.cpp
@@ -8,6 +8,7 @@
 
 #include "TimeshiftBuffer.h"
 
+#include "url/URL.h"
 #include "../utils/DiskUtils.h"
 #include "../utils/Log.h"
 
@@ -76,9 +77,9 @@ bool TimeshiftBuffer::Start(const std::string& streamId)
   {
     uint64_t freeSpaceMB = 0;
     if (DiskUtils::GetFreeDiskSpaceMB(m_timeshiftBufferPath, freeSpaceMB))
-      Log(LOGLEVEL_ERROR, "%s - Failed to open segment index file on disk: %s, disk free space (MB): %lld", __FUNCTION__, m_segmentIndexFilePath.c_str(), static_cast<long long>(freeSpaceMB));
+      Log(LOGLEVEL_ERROR, "%s - Failed to open segment index file on disk: %s, disk free space (MB): %lld", __FUNCTION__, CURL::GetRedacted(m_segmentIndexFilePath).c_str(), static_cast<long long>(freeSpaceMB));
     else
-      Log(LOGLEVEL_ERROR, "%s - Failed to open segment index file on disk: %s, not possible to calculate free space", __FUNCTION__, m_segmentIndexFilePath.c_str());
+      Log(LOGLEVEL_ERROR, "%s - Failed to open segment index file on disk: %s, not possible to calculate free space", __FUNCTION__, CURL::GetRedacted(m_segmentIndexFilePath).c_str());
     return false;
   }
 

--- a/src/stream/TimeshiftBuffer.h
+++ b/src/stream/TimeshiftBuffer.h
@@ -46,7 +46,7 @@ public:
   bool Seek(double timeMs);
   void SetPaused(bool paused);
 
-  void Start(const std::string& streamId);
+  bool Start(const std::string& streamId);
 
   time_t GetStartTimeSecs() { return m_startTime; }
 

--- a/src/stream/TimeshiftSegment.cpp
+++ b/src/stream/TimeshiftSegment.cpp
@@ -33,7 +33,9 @@ TimeshiftSegment::TimeshiftSegment(IManageDemuxPacket* demuxPacketManager, const
   // to load an out of memory segment for a seek operation
   if (!kodi::vfs::FileExists(m_timeshiftSegmentFilePath))
   {
-    if (m_fileHandle.OpenFileForWrite(m_timeshiftSegmentFilePath))
+    // We need to pass the overwrite parameter as true as otherwise
+    // opening on SMB for write on android will fail.
+    if (m_fileHandle.OpenFileForWrite(m_timeshiftSegmentFilePath, true))
     {
       int32_t packetCountPlaceholder = 0;
       m_fileHandle.Write(&packetCountPlaceholder, sizeof(packetCountPlaceholder));

--- a/src/stream/TimeshiftSegment.cpp
+++ b/src/stream/TimeshiftSegment.cpp
@@ -8,6 +8,7 @@
 
 #include "TimeshiftSegment.h"
 
+#include "../utils/DiskUtils.h"
 #include "../utils/Log.h"
 
 extern "C"
@@ -42,7 +43,11 @@ TimeshiftSegment::TimeshiftSegment(IManageDemuxPacket* demuxPacketManager, const
     }
     else
     {
-      Log(LOGLEVEL_ERROR, "%s - Failed to open segment file on disk: %s", __FUNCTION__, m_timeshiftSegmentFilePath.c_str());
+      uint64_t freeSpaceMB = 0;
+      if (DiskUtils::GetFreeDiskSpaceMB(timeshiftBufferPath, freeSpaceMB))
+        Log(LOGLEVEL_ERROR, "%s - Failed to open segment file on disk: %s, disk free space (MB): %lld", __FUNCTION__, m_timeshiftSegmentFilePath.c_str(), static_cast<long long>(freeSpaceMB));
+      else
+        Log(LOGLEVEL_ERROR, "%s - Failed to open segment file on disk: %s, not possible to calculate free space", __FUNCTION__, m_timeshiftSegmentFilePath.c_str());
       m_persistSegments = false;
     }
   }

--- a/src/stream/TimeshiftSegment.cpp
+++ b/src/stream/TimeshiftSegment.cpp
@@ -208,7 +208,7 @@ void TimeshiftSegment::LoadSegment()
 
   if (!m_loaded && m_fileHandle.OpenFile(m_timeshiftSegmentFilePath, ADDON_READ_NO_CACHE))
   {
-    int32_t packetCount;
+    int32_t packetCount = 0;
     m_fileHandle.Read(&packetCount, sizeof(packetCount));
 
     for (int i = 0; i < packetCount; i++)
@@ -376,7 +376,7 @@ DemuxPacket* TimeshiftSegment::ReadPacket()
 
   std::lock_guard<std::mutex> lock(m_mutex);
 
-  if (m_readPacketIndex != m_packetBuffer.size())
+  if (m_packetBuffer.size() != 0 && m_readPacketIndex != m_packetBuffer.size())
   {
     std::shared_ptr<DemuxPacket>& nextPacket = m_packetBuffer[m_readPacketIndex++];
 

--- a/src/stream/TimeshiftSegment.cpp
+++ b/src/stream/TimeshiftSegment.cpp
@@ -8,6 +8,7 @@
 
 #include "TimeshiftSegment.h"
 
+#include "url/URL.h"
 #include "../utils/DiskUtils.h"
 #include "../utils/Log.h"
 
@@ -25,7 +26,7 @@ TimeshiftSegment::TimeshiftSegment(IManageDemuxPacket* demuxPacketManager, const
   : m_demuxPacketManager(demuxPacketManager), m_streamId(streamId), m_segmentId(segmentId)
 {
   m_segmentFilename = StringUtils::Format("%s-%08d.seg", streamId.c_str(), segmentId);
-  Log(LOGLEVEL_DEBUG, "%s - Segment ID: %d, Segment Filename: %s", __FUNCTION__, segmentId, m_segmentFilename.c_str());
+  Log(LOGLEVEL_DEBUG, "%s - Segment ID: %d, Segment Filename: %s", __FUNCTION__, segmentId, CURL::GetRedacted(m_segmentFilename).c_str());
 
   m_timeshiftSegmentFilePath = timeshiftBufferPath + "/" + m_segmentFilename;
 
@@ -45,9 +46,9 @@ TimeshiftSegment::TimeshiftSegment(IManageDemuxPacket* demuxPacketManager, const
     {
       uint64_t freeSpaceMB = 0;
       if (DiskUtils::GetFreeDiskSpaceMB(timeshiftBufferPath, freeSpaceMB))
-        Log(LOGLEVEL_ERROR, "%s - Failed to open segment file on disk: %s, disk free space (MB): %lld", __FUNCTION__, m_timeshiftSegmentFilePath.c_str(), static_cast<long long>(freeSpaceMB));
+        Log(LOGLEVEL_ERROR, "%s - Failed to open segment file on disk: %s, disk free space (MB): %lld", __FUNCTION__, CURL::GetRedacted(m_timeshiftSegmentFilePath).c_str(), static_cast<long long>(freeSpaceMB));
       else
-        Log(LOGLEVEL_ERROR, "%s - Failed to open segment file on disk: %s, not possible to calculate free space", __FUNCTION__, m_timeshiftSegmentFilePath.c_str());
+        Log(LOGLEVEL_ERROR, "%s - Failed to open segment file on disk: %s, not possible to calculate free space", __FUNCTION__, CURL::GetRedacted(m_timeshiftSegmentFilePath).c_str());
       m_persistSegments = false;
     }
   }

--- a/src/stream/TimeshiftStream.cpp
+++ b/src/stream/TimeshiftStream.cpp
@@ -137,9 +137,6 @@ bool TimeshiftStream::IsRealTimeStream()
 
 bool TimeshiftStream::DemuxSeekTime(double timeMs, bool backwards, double& startpts)
 {
-  if (timeMs < 0)
-    return false;
-
   return m_timeshiftBuffer.Seek(timeMs);
 }
 

--- a/src/stream/TimeshiftStream.cpp
+++ b/src/stream/TimeshiftStream.cpp
@@ -24,9 +24,9 @@
 using namespace ffmpegdirect;
 
 TimeshiftStream::TimeshiftStream(IManageDemuxPacket* demuxPacketManager,
-                                 const Properties props,
+                                 const Properties& props,
                                  const HttpProxy& httpProxy)
-  : FFmpegStream(demuxPacketManager, props.m_openMode, httpProxy)
+  : FFmpegStream(demuxPacketManager, props, httpProxy)
 {
   std::random_device randomDevice; //Will be used to obtain a seed for the random number engine
   m_randomGenerator = std::mt19937(randomDevice()); //Standard mersenne_twister_engine seeded with randomDevice()

--- a/src/stream/TimeshiftStream.h
+++ b/src/stream/TimeshiftStream.h
@@ -28,7 +28,7 @@ class TimeshiftStream
 {
 public:
   TimeshiftStream(IManageDemuxPacket* demuxPacketManager,
-                  const Properties props,
+                  const Properties& props,
                   const HttpProxy& httpProxy);
   ~TimeshiftStream();
 

--- a/src/utils/DiskUtils.cpp
+++ b/src/utils/DiskUtils.cpp
@@ -1,0 +1,28 @@
+/*
+ *  Copyright (C) 2005-2020 Team Kodi
+ *  https://kodi.tv
+ *
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *  See LICENSE.md for more information.
+ */
+
+#include "DiskUtils.h"
+
+#include <limits>
+
+#include <kodi/Filesystem.h>
+#include <p8-platform/util/StringUtils.h>
+
+using namespace ffmpegdirect;
+
+bool DiskUtils::GetFreeDiskSpaceMB(const std::string& path, uint64_t& freeMB)
+{
+  uint64_t capacity = std::numeric_limits<uint64_t>::max();
+  uint64_t free = std::numeric_limits<uint64_t>::max();
+  uint64_t available = std::numeric_limits<uint64_t>::max();
+  bool success = kodi::vfs::GetDiskSpace(path, capacity, free, available);
+
+  freeMB = free / 1024 /1024;
+
+  return success;
+}

--- a/src/utils/DiskUtils.h
+++ b/src/utils/DiskUtils.h
@@ -1,0 +1,20 @@
+/*
+ *  Copyright (C) 2005-2020 Team Kodi
+ *  https://kodi.tv
+ *
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *  See LICENSE.md for more information.
+ */
+
+#pragma once
+
+#include <string>
+
+namespace ffmpegdirect
+{
+  class DiskUtils
+  {
+  public:
+    static bool GetFreeDiskSpaceMB(const std::string& path, uint64_t& freeMB);
+  };
+} //namespace ffmpegdirect


### PR DESCRIPTION
v1.15.0
- Added: Add fast open for manifest stream and test setting for realtime off
- Fixed: Honour realtime stream property
- Fixed: Fix using prev button to seek back to start of stream
- Fixed: Ensure no slash at end of timeshift buffer path
- Fixed: Make sure write segment file is closed when buffer is destroyed
- Fixed: Use overwrite when opening files for write for compatibility with SMB on Android
- Fixed: Don't start timeshift and exit if index file cannot be created
- Update: If any timeshift file cannot be created log free disk space
- Fixed: Avoid crash for zero byte or partial timeshift segment files
- Fixed: Only read ffmpeg logging setting on stream start
- Update: Redact username and password for urls in log statements
- Fixed: Only create timeshift directory if it does not exist
