### PR TITLE
[Matrix] API related change

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,16 +1,12 @@
 language: cpp
 
-#
-# Define the build matrix
-#
-# Travis defaults to building on Ubuntu Trusty when building on
-# Linux. We need Xenial in order to get up to date versions of
-# cmake and g++.
-#
 env:
   global:
     - app_id=inputstream.ffmpegdirect
 
+#
+# Define the build matrix
+#
 matrix:
   include:
     - os: linux
@@ -21,10 +17,22 @@ matrix:
       dist: xenial
       sudo: required
       compiler: clang
+    - os: linux
+      dist: bionic
+      sudo: required
+      compiler: gcc
+      env: DEBIAN_BUILD=true
+    - os: linux
+      dist: focal
+      sudo: required
+      compiler: gcc
+      env: DEBIAN_BUILD=true
     - os: osx
       osx_image: xcode10.2
 
 before_install:
+  - if [[ $DEBIAN_BUILD == true ]]; then sudo add-apt-repository -y ppa:team-xbmc/xbmc-nightly; fi
+  - if [[ $DEBIAN_BUILD == true ]]; then sudo apt-get install fakeroot; fi
   - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then sudo apt-get update -qq; fi
   - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then sudo apt-get install -y yasm autopoint; fi
   - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew install yasm gettext; fi
@@ -35,11 +43,15 @@ before_install:
 # we'll put the Kodi source on the same level
 #
 before_script:
-  - cd $TRAVIS_BUILD_DIR/..
-  - git clone --branch master --depth=1 https://github.com/xbmc/xbmc.git
-  - cd ${app_id} && mkdir build && cd build
-  - mkdir -p definition/${app_id}
-  - echo ${app_id} $TRAVIS_BUILD_DIR $TRAVIS_COMMIT > definition/${app_id}/${app_id}.txt
-  - cmake -DADDONS_TO_BUILD=${app_id} -DADDON_SRC_PREFIX=$TRAVIS_BUILD_DIR/.. -DADDONS_DEFINITION_DIR=$TRAVIS_BUILD_DIR/build/definition -DCMAKE_BUILD_TYPE=Debug -DCMAKE_INSTALL_PREFIX=$TRAVIS_BUILD_DIR/../xbmc/addons -DPACKAGE_ZIP=1 $TRAVIS_BUILD_DIR/../xbmc/cmake/addons
+  - if [[ $DEBIAN_BUILD != true ]]; then cd $TRAVIS_BUILD_DIR/..; fi
+  - if [[ $DEBIAN_BUILD != true ]]; then git clone --branch master --depth=1 https://github.com/xbmc/xbmc.git; fi
+  - if [[ $DEBIAN_BUILD != true ]]; then cd ${app_id} && mkdir build && cd build; fi
+  - if [[ $DEBIAN_BUILD != true ]]; then mkdir -p definition/${app_id}; fi
+  - if [[ $DEBIAN_BUILD != true ]]; then echo ${app_id} $TRAVIS_BUILD_DIR $TRAVIS_COMMIT > definition/${app_id}/${app_id}.txt; fi
+  - if [[ $DEBIAN_BUILD != true ]]; then cmake -DADDONS_TO_BUILD=${app_id} -DADDON_SRC_PREFIX=$TRAVIS_BUILD_DIR/.. -DADDONS_DEFINITION_DIR=$TRAVIS_BUILD_DIR/build/definition -DCMAKE_BUILD_TYPE=Debug -DCMAKE_INSTALL_PREFIX=$TRAVIS_BUILD_DIR/../xbmc/addons -DPACKAGE_ZIP=1 $TRAVIS_BUILD_DIR/../xbmc/cmake/addons; fi
+  - if [[ $DEBIAN_BUILD == true ]]; then wget https://raw.githubusercontent.com/xbmc/xbmc/master/xbmc/addons/kodi-dev-kit/tools/debian-addon-package-test.sh && chmod +x ./debian-addon-package-test.sh; fi
+  - if [[ $DEBIAN_BUILD == true ]]; then sudo apt-get build-dep $TRAVIS_BUILD_DIR; fi
 
-script: make
+script:
+  - if [[ $DEBIAN_BUILD != true ]]; then make; fi
+  - if [[ $DEBIAN_BUILD == true ]]; then ./debian-addon-package-test.sh $TRAVIS_BUILD_DIR; fi

--- a/inputstream.ffmpegdirect/addon.xml.in
+++ b/inputstream.ffmpegdirect/addon.xml.in
@@ -14,10 +14,12 @@
     library_@PLATFORM@="@LIBRARY_FILENAME@" />
   <extension point="xbmc.service" library="resources/lib/runner.py"/>
   <extension point="xbmc.addon.metadata">
+    <summary lang="de_DE">InputStream Client für FFmpeg-Streams (libavformat)</summary>
     <summary lang="en_GB">InputStream Client for FFmpeg streams (libavformat)</summary>
+    <description lang="de_DE">InputStream-Client für Streams, die entweder mit dem libav-Format von FFmpeg oder mit cURL von Kodi geöffnet werden können. Gängige Stream-Formate wie TS, HLS und DASH (ohne DRM) werden ebenso unterstützt wie viele andere.&#10;    &#10;Das Addon unterstützt auch Archiv-/Aufholdienste, bei denen Wiedergabefenster vorhanden sind (normalerweise in Tagen), und kann über diesen Zeitraum hinweg eine Zeitverschiebung bewirken.&#10;    &#10;Dokumentation finden Sie unter: https://github.com/xbmc/inputstream.ffmpegdirect/blob/Matrix/README.md&#10;    </description>
     <description lang="en_GB">InputStream Client for streams that can be opened by either FFmpeg's libavformat or Kodi's cURL. Common stream formats such as plain TS, HLS and DASH (without DRM) are supported as well as many others.&#10;    &#10;The addon also has support for Archive/Catchup services where there is a replay windows (usually in days) and can timeshift across that span.&#10;    &#10;For documenation visit: https://github.com/xbmc/inputstream.ffmpegdirect/blob/Matrix/README.md&#10;    </description>
     <platform>@PLATFORM@</platform>
-	  <license>GPL-2.0-or-later</license>
+    <license>GPL-2.0-or-later</license>
     <source>https://github.com/xbmc/inputstream.ffmpegdirect</source>
     <assets>
       <icon>icon.png</icon>

--- a/inputstream.ffmpegdirect/addon.xml.in
+++ b/inputstream.ffmpegdirect/addon.xml.in
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <addon
   id="inputstream.ffmpegdirect"
-  version="1.15.5"
+  version="1.16.0"
   name="Inputstream FFmpeg Direct"
   provider-name="Ross Nicholson">
   <requires>@ADDON_DEPENDS@</requires>
@@ -26,6 +26,11 @@
       <fanart>fanart.jpg</fanart>
     </assets>
     <news>
+v1.16.0
+- Update: Inputstream API 2.3.4
+- Added: German translation
+- Added: Debian build test to Travis CI
+
 v1.15.5
 - Update: Use add-on supplied StringUtils and remove local version
 - Update: Remove local threading code and use addon supplied instead

--- a/inputstream.ffmpegdirect/changelog.txt
+++ b/inputstream.ffmpegdirect/changelog.txt
@@ -1,3 +1,8 @@
+v1.16.0
+- Update: Inputstream API 2.3.4
+- Added: German translation
+- Added: Debian build test to Travis CI
+
 v1.15.5
 - Update: Use add-on supplied StringUtils and remove local version
 - Update: Remove local threading code and use addon supplied instead

--- a/inputstream.ffmpegdirect/resources/language/resource.language.de_de/strings.po
+++ b/inputstream.ffmpegdirect/resources/language/resource.language.de_de/strings.po
@@ -9,7 +9,7 @@ msgstr ""
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Language: en_GB\n"
+"Language: de_DE\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
 #. settings labels
@@ -17,47 +17,47 @@ msgstr ""
 #. label-category: Network
 msgctxt "#30000"
 msgid "Network"
-msgstr ""
+msgstr "Netzwerk"
 
 #. label-group: Network - httpProxy
 msgctxt "#30001"
 msgid "HTTP proxy"
-msgstr ""
+msgstr "HTTP-Proxy"
 
 #. label: Network - useHttpProxy
 msgctxt "#30002"
 msgid "Use HTTP proxy when opening with FFmpeg"
-msgstr ""
+msgstr "Verwenden Sie beim Öffnen mit FFmpeg den HTTP-Proxy"
 
 #. label-option: Network - httpProxyHost
 msgctxt "#30003"
 msgid "Server"
-msgstr ""
+msgstr "Server"
 
 #. label-option: Network - httpProxyPort
 msgctxt "#30004"
 msgid "Port"
-msgstr ""
+msgstr "Port"
 
 #. label-option: Network - httpProxyUser
 msgctxt "#30005"
 msgid "Username"
-msgstr ""
+msgstr "Benutzername"
 
 #. label-option: Network - httpProxyPassword
 msgctxt "#30006"
 msgid "Password"
-msgstr ""
+msgstr "Passwort"
 
 #. label-group: Network - Bandwidth
 msgctxt "#30007"
 msgid "Bandwidth"
-msgstr ""
+msgstr "Bandbreite"
 
 #. label-option: Network - networkBandwidth
 msgctxt "#30008"
 msgid "Stream selection bandwidth"
-msgstr ""
+msgstr "Stream-Auswahlbandbreite"
 
 #empty strings from id 30009 to 30019
 
@@ -65,65 +65,65 @@ msgstr ""
 #. label-group: Timeshift - Timeshift
 msgctxt "#30020"
 msgid "Timeshift"
-msgstr ""
+msgstr "Timeshift"
 
 #. label: Timeshift - timeshiftBufferPath
 msgctxt "#30021"
 msgid "Timeshift buffer path"
-msgstr ""
+msgstr "Timeshift-Pufferpfad"
 
 #. label: Timeshift - timeshiftEnableLimit
 msgctxt "#30022"
 msgid "Enable timeshift limit"
-msgstr ""
+msgstr "Timeshift-Limit aktivieren"
 
 #. label: Timeshift - timeshiftOnDiskLength
 msgctxt "#30023"
 msgid "Maximum timeshift buffer length"
-msgstr ""
+msgstr "Maximale Länge des Timeshift-Puffers"
 
 #. format-label: Timeshift - timeshiftOnDiskLength
 msgctxt "#30024"
 msgid "{0:.2f} hours"
-msgstr ""
+msgstr "{0:.2f} Stunden"
 
 #empty strings from id 30025 to 30039
 
 #. label-category: advanced
 msgctxt "#30040"
 msgid "Advanced"
-msgstr ""
+msgstr "Fortgeschritten"
 
 #. label-category: advanced
 #. label-group: Advanced - Logging
 msgctxt "#30041"
 msgid "FFmpeg"
-msgstr ""
+msgstr "FFmpeg"
 
 #. label: Advanced - allowFFmpegLogging
 msgctxt "#30042"
 msgid "Allow FFmpeg logging"
-msgstr ""
+msgstr "FFmpeg-Protokollierung zulassen"
 
 #. label: Advanced - probeForFps
 msgctxt "#30043"
 msgid "Probe for FPS"
-msgstr ""
+msgstr "Prüfe FPS"
 
 #. label: Advanced - enableTeletext
 msgctxt "#30044"
 msgid "Enable teletext"
-msgstr ""
+msgstr "Videotext aktivieren"
 
 #. help: Advanced - useFastOpemForManifestStreams
 msgctxt "#30045"
 msgid "Use fast open for streams using a manifest file"
-msgstr ""
+msgstr "Benutzte schnelles Öffnen von Streams mit Manifestdatei"
 
 #. help: Advanced - forceRealtimeOffCatchup
 msgctxt "#30046"
 msgid "For catchup streams report stream is not realtime"
-msgstr ""
+msgstr "Für \"Catch Up\"-Streams ist der Berichtsstrom nicht in Echtzeit"
 
 #empty strings from id 30047 to 30599
 
@@ -136,37 +136,37 @@ msgstr ""
 #. help-category: Network
 msgctxt "#30600"
 msgid "This category contains the settings for network configuration such as FFmpeg proxy and bandwidth limits."
-msgstr ""
+msgstr "Diese Kategorie enthält die Einstellungen für die Netzwerkkonfiguration, z. B. FFmpeg-Proxy und Bandbreitenbeschränkungen."
 
 #. help: Network - useHttpProxy
 msgctxt "#30601"
 msgid "Whether or not a proxy should be used when opening with FFmpeg. Note that if opened using curl kodi's proxy settings will be used."
-msgstr ""
+msgstr "Gibt an, ob beim Öffnen mit FFmpeg ein Proxy verwendet werden soll. Beachten Sie, dass beim Öffnen mit Curl Kodi die Proxy-Einstellungen verwendet werden."
 
 #. help: Network - httpProxyHost
 msgctxt "#30602"
 msgid "Configure the proxy server address."
-msgstr ""
+msgstr "Konfiguriert die Proxy-Server-Adresse."
 
 #. help: Network- httpProxyPort
 msgctxt "#30603"
 msgid "Configure the proxy server port."
-msgstr ""
+msgstr "Konfiguriert den Proxyserver-Port."
 
 #. help: Network - httpProxyUser
 msgctxt "#30604"
 msgid "Configure the proxy server username."
-msgstr ""
+msgstr "Konfiguriert den Benutzernamen des Proxyservers."
 
 #. help: Network - httpProxyPassword
 msgctxt "#30605"
 msgid "Configure the proxy server password."
-msgstr ""
+msgstr "Konfiguriert das Proxy-Server-Passwort."
 
 #. help: Network - streamBandwidth
 msgctxt "#30606"
 msgid "Use this value as a maximum when selecting which HLS stream to use."
-msgstr ""
+msgstr "Verwenden Sie diesen Wert maximal, wenn Sie den zu verwendenden HLS-Stream auswählen."
 
 #empty strings from id 30607 to 30619
 
@@ -175,22 +175,22 @@ msgstr ""
 #. help-category: timeshift
 msgctxt "#30620"
 msgid "This category contains the settings for timeshift. Timeshifting allows you to pause live TV as well as move back and forward from your current position similar to playing back a recording."
-msgstr ""
+msgstr "Diese Kategorie enthält die Einstellungen für die Zeitverschiebung. Mit Timeshifting können Sie das Live-Fernsehen anhalten und sich von Ihrer aktuellen Position aus vorwärts und rückwärts bewegen, ähnlich wie bei der Wiedergabe einer Aufnahme."
 
 #. help: Timeshift - timeshiftBufferPath
 msgctxt "#30621"
 msgid "The path used to store the timeshift buffer. The default is the [I]\"addon_data/inputstream.ffmpegdirect/timeshift\"[/I] folder in userdata. Note that this folder will be cleared  of timeshift files on Kodi startup. Only relevant when [I]\"inputstream.ffmpegdirect.stream_mode=timeshift\"[/I] property is passed to the addon."
-msgstr ""
+msgstr "Der Pfad zum Speichern des Timeshift-Puffers. Der Standardwert ist der Ordner [I]\"addon_data/inputstream.ffmpegdirect/timeshift\"[/I] in den Benutzerdaten. Beachten Sie, dass dieser Ordner beim Kodi-Start von Timeshift-Dateien befreit wird. Nur relevant, wenn die Eigenschaft [I]\"inputstream.ffmpegdirect.stream_mode=timeshift\"[/I] an das Addon übergeben wird"
 
 #. help: Timeshift - timeshiftEnableLimit
 msgctxt "#30622"
 msgid "Enable this option to limit the length of the timeshift buffer. If disabled the buffer will grow forever until playback is stopped. Regardless of this setting the buffer will also grow forever if paused."
-msgstr ""
+msgstr "Aktivieren Sie diese Option, um die Länge des Timeshift-Puffers zu begrenzen. Wenn deaktiviert, wächst der Puffer für immer, bis die Wiedergabe gestoppt wird. Unabhängig von dieser Einstellung wächst der Puffer auch für immer, wenn er angehalten wird."
 
 #. help: Timeshift - timeshiftOnDiskLength
 msgctxt "#30623"
 msgid "The length of the timeshift buffer in hours. Once the value is reached the older buffer data will be deleted to ensure the limit is not breached. Note that the storage for your device should be sufficient to allow the buffer to grow to it's maximum length (otherwise it's equivalent to disabling this option). A good heuristic for video size is 130MB per minute of 1080p video and 375MB per minute of 4K video."
-msgstr ""
+msgstr "Die Länge des Timeshift-Puffers in Stunden. Sobald der Wert erreicht ist, werden die älteren Pufferdaten gelöscht, um sicherzustellen, dass das Limit nicht überschritten wird. Beachten Sie, dass der Speicherplatz für Ihr Gerät ausreichen sollte, damit der Puffer auf seine maximale Länge anwachsen kann (andernfalls entspricht dies dem Deaktivieren dieser Option). Eine gute Heuristik für die Videogröße sind 130 MB pro Minute 1080p-Video und 375 MB pro Minute 4K-Video."
 
 #empty strings from id 30624 to 30639
 
@@ -199,29 +199,29 @@ msgstr ""
 #. help-category: advanced
 msgctxt "#30640"
 msgid "Advanced settings"
-msgstr ""
+msgstr "Erweiterte Einstellungen"
 
 #. help: Advanced - allowFFmpegLogging
 msgctxt "#30641"
 msgid "If enabled the addon will log any FFmpeg logging to the Kodi log."
-msgstr ""
+msgstr "Wenn aktiviert, protokolliert das Addon alle FFmpeg-Protokolle im Kodi-Protokoll."
 
 #. help: Advanced - probeForFps
 msgctxt "#30642"
 msgid "Probe for frames per second. Default enabled. If disabled the value returned by the codec will be used."
-msgstr ""
+msgstr "Prüfe für Bilder pro Sekunde. Standard aktiviert. Wenn deaktiviert, wird der vom Codec zurückgegebene Wert verwendet."
 
 #. help: Advanced - enableTeletext
 msgctxt "#30643"
 msgid "Allow teletext. Default enabled."
-msgstr ""
+msgstr "Videotext zulassen. Standard aktiviert."
 
 #. help: Advanced - useFastOpenForManifestStreams
 msgctxt "#30644"
 msgid "Streams which have a manifest file (e.g. HLD/DASH/Smooth Streaming) can be opened more quickly with FFmpeg with this option enabled."
-msgstr ""
+msgstr "Streams mit einer Manifestdatei (z.B. HLD/DASH/Smooth Streaming) können mit FFmpeg mit aktivierter Option schneller geöffnet werden."
 
 #. help: Advanced - forceRealtimeOffCatchup
 msgctxt "#30645"
 msgid "For certain catchup streams such as HLS reporting that a live stream is not live can improve stream open times. If testing this option works for a catchup stream/provider, then add a [I]\"#KODIPROP=inputstream.ffmpegdirect.is_realtime_stream=false\"[/I] to the M3U entry in question. This setting should not be left enabled for all streams."
-msgstr ""
+msgstr "Bei bestimmten \"Catch Up\"-Streams wie HLS kann die Meldung, dass ein Live-Stream nicht live ist, die Öffnungszeiten des Streams verbessern. Wenn das Testen dieser Option für einen Catchup-Stream/Anbieter funktioniert, fügen Sie dem betreffenden M3U-Eintrag ein [I]\"#KODIPROP=inputstream.ffmpegdirect.is_realtime_stream=false\"[/I] hinzu. Diese Einstellung sollte nicht für alle Streams aktiviert bleiben"

--- a/src/stream/FFmpegStream.cpp
+++ b/src/stream/FFmpegStream.cpp
@@ -195,10 +195,10 @@ INPUTSTREAM_IDS FFmpegStream::GetStreamIds()
 
     for (const auto& streamPair : m_streams)
     {
-      if (iids.m_streamCount < INPUTSTREAM_IDS::MAX_STREAM_COUNT)
+      if (iids.m_streamCount < INPUTSTREAM_MAX_STREAM_COUNT)
         iids.m_streamIds[iids.m_streamCount++] = streamPair.second->uniqueId;
       else
-        Log(LOGLEVEL_ERROR, "Too many streams, only %u supported", INPUTSTREAM_IDS::MAX_STREAM_COUNT);
+        Log(LOGLEVEL_ERROR, "Too many streams, only %u supported", INPUTSTREAM_MAX_STREAM_COUNT);
     }
   }
 

--- a/src/stream/TimeshiftSegment.cpp
+++ b/src/stream/TimeshiftSegment.cpp
@@ -279,7 +279,7 @@ int TimeshiftSegment::LoadPacket(std::shared_ptr<DemuxPacket>& packet)
     int numSubSamples;
     m_fileHandle.Read(&numSubSamples, sizeof(numSubSamples));
 
-    packet->cryptoInfo = std::make_shared<DemuxCryptoInfo>(numSubSamples);
+    packet->cryptoInfo = new DemuxCryptoInfo(numSubSamples);
     m_fileHandle.Read(&packet->cryptoInfo->flags, sizeof(packet->cryptoInfo->flags));
     if (numSubSamples > 0)
     {
@@ -323,6 +323,10 @@ void TimeshiftSegment::ClearPackets()
   for (auto& demuxPacket : m_packetBuffer)
   {
     delete[] demuxPacket->pData;
+    if (demuxPacket->cryptoInfo)
+    {
+      delete demuxPacket->cryptoInfo;
+    }
     FreeSideData(demuxPacket);
   }
 


### PR DESCRIPTION
This change is related to request on Kodi here: xbmc/xbmc#18352
About API was no code change needed here, only recompile.

And to make a reduced and splitted change about API cleanup (related to xbmc/xbmc#17438).

Added few other commits that it is not alone by his version increase.

Here about the changed text:
![Bildschirmfoto von 2020-08-31 11-39-43](https://user-images.githubusercontent.com/6879739/91709548-345d6300-eb83-11ea-92de-747e9b186698.png)
Before was with `"` not complete correct and a ` not direct usable
