### PR TITLE
Use msys2 mirror

### DIFF
--- a/depends/windows/mingw/CMakeLists.txt
+++ b/depends/windows/mingw/CMakeLists.txt
@@ -2,7 +2,7 @@ cmake_minimum_required(VERSION 3.5)
 project(mingw)
 
 # Currently unused (our mirrors bring some download problems for Msys2)
-if(1)
+if(0)
   foreach(repo msys mingw32 mingw64)
     if(${repo} STREQUAL msys)
       file(WRITE ${CMAKE_CURRENT_SOURCE_DIR}/etc/pacman.d/mirrorlist.${repo} "Server = http://mirrors.kodi.tv/build-deps/win32/msys2/repos/${repo}2/$arch\n")

--- a/depends/windowsstore/mingw/CMakeLists.txt
+++ b/depends/windowsstore/mingw/CMakeLists.txt
@@ -2,7 +2,7 @@ cmake_minimum_required(VERSION 3.5)
 project(mingw)
 
 # Currently unused (our mirrors bring some download problems for Msys2)
-if(1)
+if(0)
   foreach(repo msys mingw32 mingw64)
     if(${repo} STREQUAL msys)
       file(WRITE ${CMAKE_CURRENT_SOURCE_DIR}/etc/pacman.d/mirrorlist.${repo} "Server = http://mirrors.kodi.tv/build-deps/win32/msys2/repos/${repo}2/$arch\n")

--- a/inputstream.ffmpegdirect/addon.xml.in
+++ b/inputstream.ffmpegdirect/addon.xml.in
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <addon
   id="inputstream.ffmpegdirect"
-  version="1.18.0"
+  version="1.18.1"
   name="Inputstream FFmpeg Direct"
   provider-name="Ross Nicholson">
   <requires>@ADDON_DEPENDS@</requires>
@@ -25,9 +25,13 @@
       <icon>icon.png</icon>
       <fanart>fanart.jpg</fanart>
     </assets>
-    <news>v1.18.0
+    <news>
+v1.18.1
+- Update: Restore using msys2 repo for mingw packages for windows
+
+v1.18.0
 - Update: inputstream API 3.0.1
-  - Fix wrong flags bit shift
+- Fix wrong flags bit shift
 
 v1.17.0
 - Update: inputstream API 3.0.0

--- a/inputstream.ffmpegdirect/changelog.txt
+++ b/inputstream.ffmpegdirect/changelog.txt
@@ -1,6 +1,9 @@
+v1.18.1
+- Update: Restore using msys2 repo for mingw packages for windows
+
 v1.18.0
 - Update: inputstream API 3.0.1
-  - Fix wrong flags bit shift
+- Fix wrong flags bit shift
 
 v1.17.0
 - Update: inputstream API 3.0.0


### PR DESCRIPTION
v1.15.6
- Update: Restore using msys2 repo for mingw packages for windows

Until this PR passes CI it means the msys2 repo is still broken. Whenever it starts to work again this PR should be merged.

Note that this change only effects windows.