### PR TITLE
[windows] Use curl with msys2

### DIFF
--- a/depends/windows/mingw/03-usecurl.patch
+++ b/depends/windows/mingw/03-usecurl.patch
@@ -1,0 +1,11 @@
+--- a/etc/pacman.conf	Fri Jul 15 02:58:59 2016
++++ b/etc/pacman.conf	Tue Oct 20 20:36:28 2020
+@@ -15,7 +15,7 @@
+ #LogFile     = /var/log/pacman.log
+ #GPGDir      = /etc/pacman.d/gnupg/
+ HoldPkg      = pacman
+-#XferCommand = /usr/bin/curl -C - -f %u > %o
++XferCommand = /usr/bin/curl -k -L -s -C - -f %u > %o
+ #XferCommand = /usr/bin/wget --passive-ftp -c -O %o %u
+ #CleanMethod = KeepInstalled
+ #UseDelta    = 0.7


### PR DESCRIPTION
Patch pacman.conf to use curl whichl handles SSL and timeout issues better than pacman.  Options used  are -k (insecure)  -L (follow redirects) and -s (silent)  When -s is not used there is curl progress output when the 47 files are downloaded but the filename is still not shown.