### PR TITLE
fix cross build by checking CMAKE_CROSSCOMPILING

### DIFF
--- a/depends/common/ffmpeg/CMakeLists.txt
+++ b/depends/common/ffmpeg/CMakeLists.txt
@@ -54,11 +54,7 @@ if(NOT WIN32)
     list(APPEND EXTRA_CONF --cc=${CMAKE_C_COMPILER} --cxx=${CMAKE_CXX_COMPILER})
   endif()
 
-  if(CORE_SYSTEM_NAME STREQUAL android OR CORE_SYSTEM_NAME STREQUAL darwin_embedded OR CORE_PLATFORM_NAME STREQUAL rbpi)
-    set(CROSSCOMPILING 1)
-  endif()
-
-  if(CROSSCOMPILING)
+  if(CMAKE_CROSSCOMPILING)
     list(APPEND EXTRA_CONF --enable-cross-compile --arch=${CPU})
     list(APPEND EXTRA_CONF --ar=${CMAKE_AR} --strip=${CMAKE_STRIP})
     message(STATUS "CROSS: ${EXTRA_CONF}")


### PR DESCRIPTION
An attempt to fix the cross build for linux arm builds. `CMAKE_CROSSCOMPILING` is set when when using a toolchain file.