### PR TITLE
FFmpeg patch for embedded EIT (EPG) data in mepgts streams

### DIFF
--- a/depends/common/ffmpeg/04-eit-mpegts-temp.patch
+++ b/depends/common/ffmpeg/04-eit-mpegts-temp.patch
@@ -1,0 +1,13 @@
+diff --git a/libavformat/mpegts.c b/libavformat/mpegts.c
+index 80d010db6c..a2003c6632 100644
+--- a/libavformat/mpegts.c
++++ b/libavformat/mpegts.c
+@@ -2352,7 +2352,7 @@ static void pmt_cb(MpegTSFilter *filter, const uint8_t *section, int section_len
+         goto out;
+
+     // stop parsing after pmt, we found header
+-    if (!ts->stream->nb_streams)
++    if (!ts->pkt)
+         ts->stop_parse = 2;
+
+     set_pmt_found(ts, h->id);

--- a/inputstream.ffmpegdirect/addon.xml.in
+++ b/inputstream.ffmpegdirect/addon.xml.in
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <addon
   id="inputstream.ffmpegdirect"
-  version="1.18.0"
+  version="1.18.1"
   name="Inputstream FFmpeg Direct"
   provider-name="Ross Nicholson">
   <requires>@ADDON_DEPENDS@</requires>
@@ -25,7 +25,11 @@
       <icon>icon.png</icon>
       <fanart>fanart.jpg</fanart>
     </assets>
-    <news>v1.18.0
+    <news>
+v1.18.1
+- Update: Add temporary ffmpeg patch for embedded EIT (EPG) data in mepgts streams
+
+v1.18.0
 - Update: inputstream API 3.0.1
   - Fix wrong flags bit shift
 

--- a/inputstream.ffmpegdirect/changelog.txt
+++ b/inputstream.ffmpegdirect/changelog.txt
@@ -1,3 +1,6 @@
+v1.18.1
+- Update: Add temporary ffmpeg patch for embedded EIT (EPG) data in mepgts streams
+
 v1.18.0
 - Update: inputstream API 3.0.1
   - Fix wrong flags bit shift


### PR DESCRIPTION
v1.18.1
- Update: Add temporary ffmpeg patch for embedded EIT (EPG) data in mepgts streams