### PR TITLE
Satip and timestamps

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -47,6 +47,7 @@ set(CATCHUP_HEADERS src/StreamManager.h
                     src/utils/FilenameUtils.h
                     src/utils/Log.h
                     src/utils/Properties.h
+                    src/utils/TimeUtils.h
                     src/stream/url/URL.h
                     src/stream/url/UrlOptions.h
                     src/stream/url/Variant.h)

--- a/depends/common/ffmpeg/05-satip-improvements.patch
+++ b/depends/common/ffmpeg/05-satip-improvements.patch
@@ -1,0 +1,271 @@
+From ed08d884ed019c32c88823667991ea0de168a85c Mon Sep 17 00:00:00 2001
+From: Aman Karmani <aman@tmm1.net>
+Date: Wed, 16 Dec 2020 12:40:16 -0800
+Subject: [PATCH 1/2] avformat/rtsp: add support for satip://
+
+The SAT>IP protocol[1] is similar to RTSP. However SAT>IP servers
+are assumed to speak only MP2T, so DESCRIBE is not used in the same
+way. When no streams are active, DESCRIBE will return 404 according
+to the spec (see section 3.5.7). When streams are active, DESCRIBE
+will return a list of all current streams along with information
+about their signal strengths.
+
+Previously, attemping to use ffmpeg with a rtsp:// url that points
+to a SAT>IP server would work with some devices, but fail due to 404
+response on others. Further, if the SAT>IP server was already
+streaming, ffmpeg would incorrectly consume the DESCRIBE SDP response
+and join an existing tuner instead of requesting a new session with
+the URL provided by the user. These issues have been noted by many
+users across the internet[2][3][4].
+
+This commit adds proper spec-compliant support for SAT>IP, including:
+
+- support for the satip:// psuedo-protocol[5]
+- avoiding the use of DESCRIBE
+- parsing and consuming the com.ses.streamID response header
+- using "Transport: RTP/AVP;unicast" because the optional "/UDP"
+  suffix confuses some servers
+
+This patch has been validated against multiple SAT>IP vendor devices:
+
+- Telestar Digibit R2
+  (https://telestar.de/en/produkt/digibit-r1-2/)
+- Kathrein EXIP 418
+  (https://www.kathrein-ds.com/en/produkte/sat-zf-verteiltechnik/sat-ip/227/exip-418)
+- Kathrein EXIP 4124
+  (https://www.kathrein-ds.com/en/products/sat-if-signal-distribution/sat-ip/226/exip-4124)
+- Megasat MEG-8000
+  (https://www.megasat.tv/produkt/sat-ip-server-3/)
+- Megasat Twin
+  (https://www.megasat.tv/en/produkt/sat-ip-server-twin/)
+- Triax TSS 400
+  (https://www.conrad.com/p/triax-tss-400-mkii-sat-ip-server-595256)
+
+[1] https://www.satip.info/sites/satip/files/resource/satip_specification_version_1_2_2.pdf
+[2] https://stackoverflow.com/questions/61194344/does-ffmpeg-violate-the-satip-specification-describe-syntax
+[3] https://github.com/kodi-pvr/pvr.iptvsimple/issues/196
+[4] https://forum.kodi.tv/showthread.php?tid=359072&pid=2995884#pid2995884
+[5] https://www.satip.info/resources/channel-lists/
+---
+ libavformat/rtsp.c    | 53 ++++++++++++++++++++++++++++++++++++++-----
+ libavformat/rtsp.h    |  6 +++++
+ libavformat/rtspdec.c |  1 +
+ 3 files changed, 54 insertions(+), 6 deletions(-)
+
+diff --git a/libavformat/rtsp.c b/libavformat/rtsp.c
+index c7ffa07d9ee9..bb561911316c 100644
+--- a/libavformat/rtsp.c
++++ b/libavformat/rtsp.c
+@@ -252,6 +252,25 @@ static void finalize_rtp_handler_init(AVFormatContext *s, RTSPStream *rtsp_st,
+     }
+ }
+
++static int init_satip_stream(AVFormatContext *s)
++{
++    RTSPState *rt = s->priv_data;
++    RTSPStream *rtsp_st = av_mallocz(sizeof(RTSPStream));
++    if (!rtsp_st)
++        return AVERROR(ENOMEM);
++    dynarray_add(&rt->rtsp_streams,
++                 &rt->nb_rtsp_streams, rtsp_st);
++
++    rtsp_st->sdp_payload_type = 33; // MP2T
++    av_strlcpy(rtsp_st->control_url,
++               rt->control_uri, sizeof(rtsp_st->control_url));
++
++    rtsp_st->stream_index = -1;
++    init_rtp_handler(&ff_mpegts_dynamic_handler, rtsp_st, NULL);
++    finalize_rtp_handler_init(s, rtsp_st, NULL);
++    return 0;
++}
++
+ /* parse the rtpmap description: <codec_name>/<clock_rate>[/<other params>] */
+ static int sdp_parse_rtpmap(AVFormatContext *s,
+                             AVStream *st, RTSPStream *rtsp_st,
+@@ -1116,6 +1135,9 @@ void ff_rtsp_parse_line(AVFormatContext *s,
+     } else if (av_stristart(p, "Content-Type:", &p)) {
+         p += strspn(p, SPACE_CHARS);
+         av_strlcpy(reply->content_type, p, sizeof(reply->content_type));
++    } else if (av_stristart(p, "com.ses.streamID:", &p)) {
++        p += strspn(p, SPACE_CHARS);
++        av_strlcpy(reply->stream_id, p, sizeof(reply->stream_id));
+     }
+ }
+
+@@ -1495,8 +1517,10 @@ int ff_rtsp_make_setup_request(AVFormatContext *s, const char *host, int port,
+         rtp_opened:
+             port = ff_rtp_get_local_rtp_port(rtsp_st->rtp_handle);
+         have_port:
+-            snprintf(transport, sizeof(transport) - 1,
+-                     "%s/UDP;", trans_pref);
++            av_strlcat(transport, trans_pref, sizeof(transport));
++            av_strlcat(transport,
++                       rt->server_type == RTSP_SERVER_SATIP ? ";" : "/UDP;",
++                       sizeof(transport));
+             if (rt->server_type != RTSP_SERVER_REAL)
+                 av_strlcat(transport, "unicast;", sizeof(transport));
+             av_strlcatf(transport, sizeof(transport),
+@@ -1559,6 +1583,15 @@ int ff_rtsp_make_setup_request(AVFormatContext *s, const char *host, int port,
+             goto fail;
+         }
+
++        if (rt->server_type == RTSP_SERVER_SATIP && reply->stream_id[0]) {
++            char proto[128], host[128], path[512], auth[128];
++            int port;
++            av_url_split(proto, sizeof(proto), auth, sizeof(auth), host, sizeof(host),
++                        &port, path, sizeof(path), rt->control_uri);
++            ff_url_join(rt->control_uri, sizeof(rt->control_uri), proto, NULL, host,
++                        port, "/stream=%s", reply->stream_id);
++        }
++
+         /* XXX: same protocol for all streams is required */
+         if (i > 0) {
+             if (reply->transports[0].lower_transport != rt->lower_transport ||
+@@ -1710,6 +1743,9 @@ int ff_rtsp_connect(AVFormatContext *s)
+         lower_rtsp_proto         = "tls";
+         default_port             = RTSPS_DEFAULT_PORT;
+         rt->lower_transport_mask = 1 << RTSP_LOWER_TRANSPORT_TCP;
++    } else if (!strcmp(proto, "satip")) {
++        av_strlcpy(proto, "rtsp", sizeof(proto));
++        rt->server_type = RTSP_SERVER_SATIP;
+     }
+
+     if (*auth) {
+@@ -1857,7 +1893,9 @@ int ff_rtsp_connect(AVFormatContext *s)
+
+     /* request options supported by the server; this also detects server
+      * type */
+-    for (rt->server_type = RTSP_SERVER_RTP;;) {
++    if (rt->server_type != RTSP_SERVER_SATIP)
++        rt->server_type = RTSP_SERVER_RTP;
++    for (;;) {
+         cmd[0] = 0;
+         if (rt->server_type == RTSP_SERVER_REAL)
+             av_strlcat(cmd,
+@@ -1892,9 +1930,12 @@ int ff_rtsp_connect(AVFormatContext *s)
+         break;
+     }
+
+-    if (CONFIG_RTSP_DEMUXER && s->iformat)
+-        err = ff_rtsp_setup_input_streams(s, reply);
+-    else if (CONFIG_RTSP_MUXER)
++    if (CONFIG_RTSP_DEMUXER && s->iformat) {
++        if (rt->server_type == RTSP_SERVER_SATIP)
++            err = init_satip_stream(s);
++        else
++            err = ff_rtsp_setup_input_streams(s, reply);
++    } else if (CONFIG_RTSP_MUXER)
+         err = ff_rtsp_setup_output_streams(s, host);
+     else
+         av_assert0(0);
+diff --git a/libavformat/rtsp.h b/libavformat/rtsp.h
+index b74cdc148a2c..239ea8a0eb9f 100644
+--- a/libavformat/rtsp.h
++++ b/libavformat/rtsp.h
+@@ -188,6 +188,11 @@ typedef struct RTSPMessageHeader {
+      * Content type header
+      */
+     char content_type[64];
++
++    /**
++     * SAT>IP com.ses.streamID header
++     */
++    char stream_id[64];
+ } RTSPMessageHeader;
+
+ /**
+@@ -210,6 +215,7 @@ enum RTSPServerType {
+     RTSP_SERVER_RTP,  /**< Standards-compliant RTP-server */
+     RTSP_SERVER_REAL, /**< Realmedia-style server */
+     RTSP_SERVER_WMS,  /**< Windows Media server */
++    RTSP_SERVER_SATIP,/**< SAT>IP server */
+     RTSP_SERVER_NB
+ };
+
+diff --git a/libavformat/rtspdec.c b/libavformat/rtspdec.c
+index bfbb01d586a6..113da975e12c 100644
+--- a/libavformat/rtspdec.c
++++ b/libavformat/rtspdec.c
+@@ -724,6 +724,7 @@ static int rtsp_probe(const AVProbeData *p)
+ #if CONFIG_TLS_PROTOCOL
+         av_strstart(p->filename, "rtsps:", NULL) ||
+ #endif
++        av_strstart(p->filename, "satip:", NULL) ||
+         av_strstart(p->filename, "rtsp:", NULL))
+         return AVPROBE_SCORE_MAX;
+     return 0;
+
+From f4cd5f621170e9680f3b1fcbf3a7205f436afe15 Mon Sep 17 00:00:00 2001
+From: Aman Karmani <aman@tmm1.net>
+Date: Mon, 21 Dec 2020 15:53:55 -0800
+Subject: [PATCH 2/2] avformat/rtsp: add satip_raw flag to receive raw mpegts
+ stream
+
+This can be used to receive the raw mpegts stream from a SAT>IP
+server, by letting avformat handle the RTSP/RTP/UDP negotiation
+and setup, but then simply passing the MP2T stream through
+instead of demuxing it further.
+
+For example, this command would demux/remux the mpegts stream:
+
+    SATIP_URL='satip://192.168.1.99:554/?src=1&freq=12188&pol=h&ro=0.35&msys=dvbs&mtype=qpsk&plts=off&sr=27500&fec=34&pids=0,17,18,167,136,47,71'
+    ffmpeg -i $SATIP_URL -map 0 -c copy -f mpegts -y remux.ts
+
+Whereas this command will simply write out the raw stream, with
+the original PAT/PMT/PIDs intact:
+
+    ffmpeg -rtsp_flags satip_raw -i $SATIP_URL -map 0 -c copy -f data -y raw.ts
+
+Signed-off-by: Aman Karmani <aman@tmm1.net>
+---
+ libavformat/rtsp.c | 17 ++++++++++++++---
+ libavformat/rtsp.h |  1 +
+ 2 files changed, 15 insertions(+), 3 deletions(-)
+
+diff --git a/libavformat/rtsp.c b/libavformat/rtsp.c
+index bb561911316c..69b0b8b11448 100644
+--- a/libavformat/rtsp.c
++++ b/libavformat/rtsp.c
+@@ -89,6 +89,7 @@ const AVOption ff_rtsp_options[] = {
+     RTSP_FLAG_OPTS("rtsp_flags", "set RTSP flags"),
+     { "listen", "wait for incoming connections", 0, AV_OPT_TYPE_CONST, {.i64 = RTSP_FLAG_LISTEN}, 0, 0, DEC, "rtsp_flags" },
+     { "prefer_tcp", "try RTP via TCP first, if available", 0, AV_OPT_TYPE_CONST, {.i64 = RTSP_FLAG_PREFER_TCP}, 0, 0, DEC|ENC, "rtsp_flags" },
++    { "satip_raw", "export raw MPEG-TS stream instead of demuxing", 0, AV_OPT_TYPE_CONST, {.i64 = RTSP_FLAG_SATIP_RAW}, 0, 0, DEC, "rtsp_flags" },
+     RTSP_MEDIATYPE_OPTS("allowed_media_types", "set media types to accept from the server"),
+     { "min_port", "set minimum local UDP port", OFFSET(rtp_port_min), AV_OPT_TYPE_INT, {.i64 = RTSP_RTP_PORT_MIN}, 0, 65535, DEC|ENC },
+     { "max_port", "set maximum local UDP port", OFFSET(rtp_port_max), AV_OPT_TYPE_INT, {.i64 = RTSP_RTP_PORT_MAX}, 0, 65535, DEC|ENC },
+@@ -265,9 +266,19 @@ static int init_satip_stream(AVFormatContext *s)
+     av_strlcpy(rtsp_st->control_url,
+                rt->control_uri, sizeof(rtsp_st->control_url));
+
+-    rtsp_st->stream_index = -1;
+-    init_rtp_handler(&ff_mpegts_dynamic_handler, rtsp_st, NULL);
+-    finalize_rtp_handler_init(s, rtsp_st, NULL);
++    if (rt->rtsp_flags & RTSP_FLAG_SATIP_RAW) {
++        AVStream *st = avformat_new_stream(s, NULL);
++        if (!st)
++            return AVERROR(ENOMEM);
++        st->id = rt->nb_rtsp_streams - 1;
++        rtsp_st->stream_index = st->index;
++        st->codecpar->codec_type = AVMEDIA_TYPE_DATA;
++        st->codecpar->codec_id   = AV_CODEC_ID_MPEG2TS;
++    } else {
++        rtsp_st->stream_index = -1;
++        init_rtp_handler(&ff_mpegts_dynamic_handler, rtsp_st, NULL);
++        finalize_rtp_handler_init(s, rtsp_st, NULL);
++    }
+     return 0;
+ }
+
+diff --git a/libavformat/rtsp.h b/libavformat/rtsp.h
+index 239ea8a0eb9f..1310dd9c08ab 100644
+--- a/libavformat/rtsp.h
++++ b/libavformat/rtsp.h
+@@ -429,6 +429,7 @@ typedef struct RTSPState {
+ #define RTSP_FLAG_RTCP_TO_SOURCE 0x8 /**< Send RTCP packets to the source
+                                           address of received packets. */
+ #define RTSP_FLAG_PREFER_TCP  0x10   /**< Try RTP via TCP first if possible. */
++#define RTSP_FLAG_SATIP_RAW   0x20   /**< Export SAT>IP stream as raw MPEG-TS */
+
+ typedef struct RTSPSource {
+     char addr[128]; /**< Source-specific multicast include source IP address (from SDP content) */

--- a/depends/windows/mingw/03-use-curl.patch
+++ b/depends/windows/mingw/03-use-curl.patch
@@ -1,0 +1,11 @@
+--- a/etc/pacman.conf	Fri Jul 15 02:58:59 2016
++++ b/etc/pacman.conf	Tue Oct 20 20:36:28 2020
+@@ -15,7 +15,7 @@
+ #LogFile     = /var/log/pacman.log
+ #GPGDir      = /etc/pacman.d/gnupg/
+ HoldPkg      = pacman
+-#XferCommand = /usr/bin/curl -C - -f %u > %o
++XferCommand = /usr/bin/curl -k --retry 5 -L -C - -f %u > %o
+ #XferCommand = /usr/bin/wget --passive-ftp -c -O %o %u
+ #CleanMethod = KeepInstalled
+ #UseDelta    = 0.7

--- a/depends/windowsstore/mingw/03-use-curl.patch
+++ b/depends/windowsstore/mingw/03-use-curl.patch
@@ -1,0 +1,11 @@
+--- a/etc/pacman.conf	Fri Jul 15 02:58:59 2016
++++ b/etc/pacman.conf	Tue Oct 20 20:36:28 2020
+@@ -15,7 +15,7 @@
+ #LogFile     = /var/log/pacman.log
+ #GPGDir      = /etc/pacman.d/gnupg/
+ HoldPkg      = pacman
+-#XferCommand = /usr/bin/curl -C - -f %u > %o
++XferCommand = /usr/bin/curl -k --retry 5 -L -C - -f %u > %o
+ #XferCommand = /usr/bin/wget --passive-ftp -c -O %o %u
+ #CleanMethod = KeepInstalled
+ #UseDelta    = 0.7

--- a/inputstream.ffmpegdirect/addon.xml.in
+++ b/inputstream.ffmpegdirect/addon.xml.in
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <addon
   id="inputstream.ffmpegdirect"
-  version="1.18.2"
+  version="1.19.0"
   name="Inputstream FFmpeg Direct"
   provider-name="Ross Nicholson">
   <requires>@ADDON_DEPENDS@</requires>
@@ -26,6 +26,12 @@
       <fanart>fanart.jpg</fanart>
     </assets>
     <news>
+v1.19.0
+- Added: FFmpeg patch for satip improvements
+- Added: SafeLocaltime and custom catchup timestamp formats
+- Added: Now timestamp and custom timestamp format for live catchup URL
+- Added: Use curl for mingw package downloads
+
 v1.18.2
 - Update: Redact inputstream property URLs when logged
 

--- a/inputstream.ffmpegdirect/changelog.txt
+++ b/inputstream.ffmpegdirect/changelog.txt
@@ -1,3 +1,9 @@
+v1.19.0
+- Added: FFmpeg patch for satip improvements
+- Added: SafeLocaltime and custom catchup timestamp formats
+- Added: Now timestamp and custom timestamp format for live catchup URL
+- Added: Use curl for mingw package downloads
+
 v1.18.2
 - Update: Redact inputstream property URLs when logged
 

--- a/src/stream/FFmpegCatchupStream.cpp
+++ b/src/stream/FFmpegCatchupStream.cpp
@@ -27,6 +27,7 @@ extern "C" {
 #include <libavutil/opt.h>
 }
 
+#include <iomanip>
 #include <regex>
 
 //#include "platform/posix/XTimeUtils.h"
@@ -377,7 +378,7 @@ bool FFmpegCatchupStream::IsRealTimeStream()
 namespace
 {
 
-void FormatUnits(time_t tTime, const std::string& name, std::string &urlFormatString)
+void FormatUnits(const std::string& name, time_t tTime, std::string &urlFormatString)
 {
   const std::regex timeSecondsRegex(".*(\\{" + name + ":(\\d+)\\}).*");
   std::cmatch mr;
@@ -405,54 +406,94 @@ void FormatUnits(time_t tTime, const std::string& name, std::string &urlFormatSt
 
 void FormatTime(const char ch, const struct tm *pTime, std::string &urlFormatString)
 {
-  char str[] = { '{', ch, '}', 0 };
+  std::string str = {'{', ch, '}'};
   size_t pos = urlFormatString.find(str);
   while (pos != std::string::npos)
   {
-    char buff[256], timeFmt[3];
-    std::snprintf(timeFmt, sizeof(timeFmt), "%%%c", ch);
-    std::strftime(buff, sizeof(buff), timeFmt, pTime);
-    if (std::strlen(buff) > 0)
-      urlFormatString.replace(pos, 3, buff);
+    std::ostringstream os;
+    os << std::put_time(pTime, StringUtils::Format("%%%c", ch).c_str());
+    std::string timeString = os.str();
+
+    if (timeString.size() > 0)
+      urlFormatString.replace(pos, str.size(), timeString);
 
     pos = urlFormatString.find(str);
   }
 }
 
-void FormatUtc(const char *str, time_t tTime, std::string &urlFormatString)
+void FormatTime(const std::string name, const struct tm *pTime, std::string &urlFormatString, bool hasVarPrefix)
+{
+  std::string qualifier = hasVarPrefix ? "$" : "";
+  qualifier += "{" + name + ":";
+  size_t found = urlFormatString.find(qualifier);
+  if (found != std::string::npos)
+  {
+    size_t foundStart = found + qualifier.size();
+    size_t foundEnd = urlFormatString.find("}", foundStart + 1);
+    if (foundEnd != std::string::npos)
+    {
+      std::string formatString = urlFormatString.substr(foundStart, foundEnd - foundStart);
+      const std::regex timeSpecifiers("([YmdHMS])");
+      formatString = std::regex_replace(formatString, timeSpecifiers, R"(%$&)");
+
+      std::ostringstream os;
+      os << std::put_time(pTime, formatString.c_str());
+      std::string timeString = os.str();
+
+      if (timeString.size() > 0)
+        urlFormatString.replace(found, foundEnd - found + 1, timeString);
+    }
+  }
+}
+
+void FormatUtc(const std::string& str, time_t tTime, std::string &urlFormatString)
 {
   auto pos = urlFormatString.find(str);
   if (pos != std::string::npos)
   {
-    char buff[256];
-    std::snprintf(buff, sizeof(buff), "%lu", tTime);
-    urlFormatString.replace(pos, std::strlen(str), buff);
+    std::string utcTimeAsString = StringUtils::Format("%lu", tTime);
+    urlFormatString.replace(pos, str.size(), utcTimeAsString);
   }
 }
 
-std::string FormatDateTime(time_t dateTimeEpg, time_t duration, const std::string &urlFormatString)
+std::string FormatDateTime(time_t timeStart, time_t duration, const std::string &urlFormatString)
 {
   std::string formattedUrl = urlFormatString;
 
-  const time_t dateTimeNow = std::time(0);
-  tm* dateTime = std::localtime(&dateTimeEpg);
+  const time_t timeEnd = timeStart + duration;
+  const time_t timeNow = std::time(0);
 
-  FormatTime('Y', dateTime, formattedUrl);
-  FormatTime('m', dateTime, formattedUrl);
-  FormatTime('d', dateTime, formattedUrl);
-  FormatTime('H', dateTime, formattedUrl);
-  FormatTime('M', dateTime, formattedUrl);
-  FormatTime('S', dateTime, formattedUrl);
-  FormatUtc("{utc}", dateTimeEpg, formattedUrl);
-  FormatUtc("${start}", dateTimeEpg, formattedUrl);
-  FormatUtc("{utcend}", dateTimeEpg + duration, formattedUrl);
-  FormatUtc("${end}", dateTimeEpg + duration, formattedUrl);
-  FormatUtc("{lutc}", dateTimeNow, formattedUrl);
-  FormatUtc("${timestamp}", dateTimeNow, formattedUrl);
+  std::tm dateTimeStart = SafeLocaltime(timeStart);
+  std::tm dateTimeEnd = SafeLocaltime(timeEnd);
+  std::tm dateTimeNow = SafeLocaltime(timeNow);
+
+  FormatTime('Y', &dateTimeStart, formattedUrl);
+  FormatTime('m', &dateTimeStart, formattedUrl);
+  FormatTime('d', &dateTimeStart, formattedUrl);
+  FormatTime('H', &dateTimeStart, formattedUrl);
+  FormatTime('M', &dateTimeStart, formattedUrl);
+  FormatTime('S', &dateTimeStart, formattedUrl);
+  FormatUtc("{utc}", timeStart, formattedUrl);
+  FormatUtc("${start}", timeStart, formattedUrl);
+  FormatUtc("{utcend}", timeStart + duration, formattedUrl);
+  FormatUtc("${end}", timeStart + duration, formattedUrl);
+  FormatUtc("{lutc}", timeNow, formattedUrl);
+  FormatUtc("${now}", timeNow, formattedUrl);
+  FormatUtc("${timestamp}", timeNow, formattedUrl);
   FormatUtc("{duration}", duration, formattedUrl);
-  FormatUnits(duration, "duration", formattedUrl);
-  FormatUtc("${offset}", dateTimeNow - dateTimeEpg, formattedUrl);
-  FormatUnits(dateTimeNow - dateTimeEpg, "offset", formattedUrl);
+  FormatUnits("duration", duration, formattedUrl);
+  FormatUtc("${offset}", timeNow - timeStart, formattedUrl);
+  FormatUnits("offset", timeNow - timeStart, formattedUrl);
+
+  FormatTime("utc", &dateTimeStart, formattedUrl, false);
+  FormatTime("start", &dateTimeStart, formattedUrl, true);
+
+  FormatTime("utcend", &dateTimeEnd, formattedUrl, false);
+  FormatTime("end", &dateTimeEnd, formattedUrl, true);
+
+  FormatTime("lutc", &dateTimeNow, formattedUrl, false);
+  FormatTime("now", &dateTimeNow, formattedUrl, true);
+  FormatTime("timestamp", &dateTimeNow, formattedUrl, true);
 
   Log(LOGLEVEL_DEBUG, "%s - \"%s\"", __FUNCTION__, CURL::GetRedacted(formattedUrl).c_str());
 

--- a/src/stream/FFmpegCatchupStream.cpp
+++ b/src/stream/FFmpegCatchupStream.cpp
@@ -500,6 +500,24 @@ std::string FormatDateTime(time_t timeStart, time_t duration, const std::string 
   return formattedUrl;
 }
 
+std::string FormatDateTimeNowOnly(const std::string &urlFormatString)
+{
+  std::string formattedUrl = urlFormatString;
+  const time_t timeNow = std::time(0);
+  std::tm dateTimeNow = SafeLocaltime(timeNow);
+
+  FormatUtc("{lutc}", timeNow, formattedUrl);
+  FormatUtc("${now}", timeNow, formattedUrl);
+  FormatUtc("${timestamp}", timeNow, formattedUrl);
+  FormatTime("lutc", &dateTimeNow, formattedUrl, false);
+  FormatTime("now", &dateTimeNow, formattedUrl, true);
+  FormatTime("timestamp", &dateTimeNow, formattedUrl, true);
+
+  Log(LOGLEVEL_DEBUG, "%s - \"%s\"", __FUNCTION__, CURL::GetRedacted(formattedUrl).c_str());
+
+  return formattedUrl;
+}
+
 } // unnamed namespace
 
 std::string FFmpegCatchupStream::GetUpdatedCatchupUrl() const
@@ -541,5 +559,5 @@ std::string FFmpegCatchupStream::GetUpdatedCatchupUrl() const
   }
 
   Log(LOGLEVEL_DEBUG, "%s - Default URL: %s", __FUNCTION__, CURL::GetRedacted(m_defaultUrl).c_str());
-  return m_defaultUrl;
+  return FormatDateTimeNowOnly(m_defaultUrl);
 }

--- a/src/stream/FFmpegCatchupStream.h
+++ b/src/stream/FFmpegCatchupStream.h
@@ -10,6 +10,7 @@
 
 #include "FFmpegStream.h"
 #include "../utils/HttpProxy.h"
+#include "../utils/TimeUtils.h"
 
 namespace ffmpegdirect
 {
@@ -51,7 +52,7 @@ protected:
   bool TargetDistanceFromLiveSupported(long long secondsFromLive);
   const std::string GetDateTime(time_t time)
   {
-    std::tm timeStruct = *localtime(&time);
+    std::tm timeStruct = SafeLocaltime(time);
     char buffer[32];
     std::strftime(buffer, sizeof(buffer), "%Y-%m-%d.%X", &timeStruct);
 

--- a/src/utils/TimeUtils.h
+++ b/src/utils/TimeUtils.h
@@ -1,0 +1,23 @@
+/*
+ *  Copyright (C) 2005-2020 Team Kodi
+ *  https://kodi.tv
+ *
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *  See LICENSE.md for more information.
+ */
+
+#pragma once
+
+#include <cstdlib>
+#include <ctime>
+
+inline std::tm SafeLocaltime(const std::time_t& time)
+{
+  std::tm tm_snapshot;
+#if (defined(WIN32) || defined(_WIN32) || defined(__WIN32__))
+  localtime_s(&tm_snapshot, &time);
+#else
+  localtime_r(&time, &tm_snapshot); // POSIX
+#endif
+  return tm_snapshot;
+}


### PR DESCRIPTION
v1.19.0
- Added: FFmpeg patch for satip improvements
- Added: Custom timestamp formats for catchup streams
- Added: Now timestamp and custom timestamp format for live catchup URL
- Added: Use curl for mingw package downloads