### PR TITLE
Pacman curl test windows is -k and UWP is not

### DIFF
--- a/depends/windows/mingw/03-use-curl.patch
+++ b/depends/windows/mingw/03-use-curl.patch
@@ -5,7 +5,7 @@
  #GPGDir      = /etc/pacman.d/gnupg/
  HoldPkg      = pacman
 -#XferCommand = /usr/bin/curl -C - -f %u > %o
-+XferCommand = /usr/bin/curl -k --retry 5 -L -C - -f %u > %o
++XferCommand = /usr/bin/curl -v -k -L -C - -f %u > %o
  #XferCommand = /usr/bin/wget --passive-ftp -c -O %o %u
  #CleanMethod = KeepInstalled
  #UseDelta    = 0.7

--- a/depends/windowsstore/mingw/03-use-curl.patch
+++ b/depends/windowsstore/mingw/03-use-curl.patch
@@ -5,7 +5,7 @@
  #GPGDir      = /etc/pacman.d/gnupg/
  HoldPkg      = pacman
 -#XferCommand = /usr/bin/curl -C - -f %u > %o
-+XferCommand = /usr/bin/curl -k --retry 5 -L -C - -f %u > %o
++XferCommand = /usr/bin/curl -v -L -C - -f %u > %o
  #XferCommand = /usr/bin/wget --passive-ftp -c -O %o %u
  #CleanMethod = KeepInstalled
  #UseDelta    = 0.7


### PR DESCRIPTION
@yol @wsnipex 

Windows logs (32 and 64 bit) use the -k flag. UWP builds do not. Both types have -v.