### PR TITLE
Ensure all values in GetTimes() default to zero

### DIFF
--- a/inputstream.ffmpegdirect/addon.xml.in
+++ b/inputstream.ffmpegdirect/addon.xml.in
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <addon
   id="inputstream.ffmpegdirect"
-  version="1.19.0"
+  version="1.19.1"
   name="Inputstream FFmpeg Direct"
   provider-name="Ross Nicholson">
   <requires>@ADDON_DEPENDS@</requires>
@@ -26,6 +26,9 @@
       <fanart>fanart.jpg</fanart>
     </assets>
     <news>
+v1.19.1
+- Fixed: Ensure all values in GetTimes() default to zero
+
 v1.19.0
 - Added: FFmpeg patch for satip improvements
 - Added: SafeLocaltime and custom catchup timestamp formats

--- a/inputstream.ffmpegdirect/changelog.txt
+++ b/inputstream.ffmpegdirect/changelog.txt
@@ -1,3 +1,6 @@
+v1.19.1
+- Fixed: Ensure all values in GetTimes() default to zero
+
 v1.19.0
 - Added: FFmpeg patch for satip improvements
 - Added: SafeLocaltime and custom catchup timestamp formats

--- a/src/stream/FFmpegCatchupStream.cpp
+++ b/src/stream/FFmpegCatchupStream.cpp
@@ -349,6 +349,9 @@ bool FFmpegCatchupStream::GetTimes(kodi::addon::InputstreamTimes& times)
   const time_t dateTimeNow = time(0);
 
   times.SetStartTime(m_catchupBufferStartTime);
+  times.SetPtsStart(0);
+  times.SetPtsBegin(0);
+
   if (m_playbackAsLive)
     times.SetPtsEnd(static_cast<double>(dateTimeNow - times.GetStartTime()) * STREAM_TIME_BASE);
   else // it's like a video
@@ -543,7 +546,7 @@ std::string FFmpegCatchupStream::GetUpdatedCatchupUrl() const
     if (offset > (timeNow - m_defaultProgrammeDuration) && !m_catchupUrlNearLiveFormatString.empty())
       urlFormatString = m_catchupUrlNearLiveFormatString;
 
-    Log(LOGLEVEL_DEBUG, "%s - Offset Time - \"%lld\" - %s", __FUNCTION__, static_cast<long long>(offset), CURL::GetRedacted(m_catchupUrlFormatString).c_str());
+    Log(LOGLEVEL_DEBUG, "%s - Offset Time - \"%lld\" - %s", __FUNCTION__, static_cast<long long>(offset), CURL::GetRedacted(urlFormatString).c_str());
 
     std::string catchupUrl = FormatDateTime(offset - m_timezoneShift, duration, urlFormatString);
 

--- a/src/stream/FFmpegStream.cpp
+++ b/src/stream/FFmpegStream.cpp
@@ -534,6 +534,8 @@ bool FFmpegStream::GetTimes(kodi::addon::InputstreamTimes& times)
   if (!IsRealTimeStream())
   {
     times.SetStartTime(0);
+    times.SetPtsStart(0);
+    times.SetPtsBegin(0);
     times.SetPtsEnd(m_pFormatContext->duration);
 
     return true;


### PR DESCRIPTION
v1.19.1
- Fixed: Ensure all values in GetTimes() default to zero