### PR TITLE
Fix locking on EOF detection of terminating catchup stream

### DIFF
--- a/inputstream.ffmpegdirect/addon.xml.in
+++ b/inputstream.ffmpegdirect/addon.xml.in
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <addon
   id="inputstream.ffmpegdirect"
-  version="1.19.3"
+  version="1.19.4"
   name="Inputstream FFmpeg Direct"
   provider-name="Ross Nicholson">
   <requires>@ADDON_DEPENDS@</requires>
@@ -26,6 +26,9 @@
       <fanart>fanart.jpg</fanart>
     </assets>
     <news>
+v1.19.4
+- Fixed: Fix locking on EOF detection of terminating catchup stream by using std:recursive_mutex
+
 v1.19.3
 - Update: move verbose playback timeshift logging to debug level
 - Update: Update cmakelists to reference FFMPEGDIRECT at build time

--- a/inputstream.ffmpegdirect/changelog.txt
+++ b/inputstream.ffmpegdirect/changelog.txt
@@ -1,3 +1,6 @@
+v1.19.4
+- Fixed: Fix locking on EOF detection of terminating catchup stream by using std:recursive_mutex
+
 v1.19.3
 - Update: move verbose playback timeshift logging to debug level
 - Update: Update cmakelists to reference FFMPEGDIRECT at build time

--- a/src/stream/FFmpegCatchupStream.cpp
+++ b/src/stream/FFmpegCatchupStream.cpp
@@ -89,7 +89,7 @@ bool FFmpegCatchupStream::DemuxSeekTime(double timeMs, bool backwards, double& s
   if (seekResult >= 0)
   {
     {
-      std::lock_guard<std::mutex> lock(m_mutex);
+      std::lock_guard<std::recursive_mutex> lock(m_mutex);
       m_seekOffset = seekResult;
     }
 
@@ -115,7 +115,7 @@ DEMUX_PACKET* FFmpegCatchupStream::DemuxRead()
   DEMUX_PACKET* pPacket = FFmpegStream::DemuxRead();
   if (pPacket)
   {
-    std::lock_guard<std::mutex> lock(m_mutex);
+    std::lock_guard<std::recursive_mutex> lock(m_mutex);
     pPacket->pts += m_seekOffset;
     pPacket->dts += m_seekOffset;
 
@@ -174,7 +174,7 @@ void FFmpegCatchupStream::DemuxSetSpeed(int speed)
   else if (!IsPaused() && speed == STREAM_PLAYSPEED_PAUSE)
   {
     // Pause Playback
-    std::lock_guard<std::mutex> lock(m_mutex);
+    std::lock_guard<std::recursive_mutex> lock(m_mutex);
     m_pauseStartTime = m_currentDemuxTime;
     Log(LOGLEVEL_DEBUG, "%s - DemuxSetSpeed - Pause time: %lld", __FUNCTION__, static_cast<long long>(m_pauseStartTime));
   }

--- a/src/stream/FFmpegStream.cpp
+++ b/src/stream/FFmpegStream.cpp
@@ -292,7 +292,7 @@ DEMUX_PACKET* FFmpegStream::DemuxRead()
   // on some cases where the received packet is invalid we will need to return an empty packet (0 length) otherwise the main loop (in CVideoPlayer)
   // would consider this the end of stream and stop.
   bool bReturnEmpty = false;
-  { std::lock_guard<std::mutex> lock(m_mutex); // open lock scope
+  { std::lock_guard<std::recursive_mutex> lock(m_mutex); // open lock scope
   if (m_pFormatContext)
   {
     // assume we are not eof
@@ -1471,7 +1471,7 @@ bool FFmpegStream::SeekTime(double time, bool backwards, double* startpts)
 
   int ret;
   {
-    std::lock_guard<std::mutex> lock(m_mutex);
+    std::lock_guard<std::recursive_mutex> lock(m_mutex);
     ret = av_seek_frame(m_pFormatContext, m_seekStream, seek_pts, backwards ? AVSEEK_FLAG_BACKWARD : 0);
 
     if (ret < 0)

--- a/src/stream/FFmpegStream.h
+++ b/src/stream/FFmpegStream.h
@@ -109,7 +109,7 @@ protected:
   virtual bool CheckReturnEmptyOnPacketResult(int result);
 
   int64_t m_demuxerId;
-  mutable std::mutex m_mutex;
+  mutable std::recursive_mutex m_mutex;
   double m_currentPts; // used for stream length estimation
   bool m_demuxResetOpenSuccess = false;
   std::string m_streamUrl;


### PR DESCRIPTION
v1.19.4
- Fixed: Fix locking on EOF detection of terminating catchup stream by using std:recursive_mutex