### PR TITLE
Ignore content length when using Curl to open files

### DIFF
--- a/inputstream.ffmpegdirect/addon.xml.in
+++ b/inputstream.ffmpegdirect/addon.xml.in
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <addon
   id="inputstream.ffmpegdirect"
-  version="1.19.4"
+  version="1.19.5"
   name="Inputstream FFmpeg Direct"
   provider-name="Ross Nicholson">
   <requires>@ADDON_DEPENDS@</requires>

--- a/src/stream/CurlInput.cpp
+++ b/src/stream/CurlInput.cpp
@@ -80,6 +80,8 @@ bool CurlInput::Open(const std::string& filename, const std::string& mimeType, u
       content == "video/x-matroska-3d")
     flags |= ADDON_READ_MULTI_STREAM;
 
+  m_pFile->CURLAddOption(ADDON_CURL_OPTION_OPTION, "CURLOPT_IGNORE_CONTENT_LENGTH", "1L");
+
   // open file in binary mode
   if (!m_pFile->OpenFile(m_filename, flags))
   {


### PR DESCRIPTION
Can be tired with the following props:

#KODIPROP:inputstream=inputstream.ffmpegdirect
#KODIPROP:mimetype=video/mp2t
#KODIPROP:inputstream.ffmpegdirect.is_realtime_stream=true
#KODIPROP:inputstream.ffmpegdirect.open_mode=curl