### PR TITLE
Deprecate av init packet for ffmpeg 4.4

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -104,12 +104,6 @@ endif()
 addon_version(inputstream.ffmpegdirect FFMPEGDIRECT)
 add_definitions(-DFFMPEGDIRECT_VERSION=${FFMPEGDIRECT_VERSION})
 
-if(CORE_SYSTEM_NAME STREQUAL windowsstore)
-  # TODO: This is required so FFmpeg's av_init_packet() deprecation does not break windows store builds
-  #       Once this function is no longer used this can and should be removed.
-  add_compile_options(/wd4996)
-endif()
-
 build_addon(inputstream.ffmpegdirect FFMPEGDIRECT DEPLIBS)
 
 if(${CMAKE_SYSTEM_NAME} MATCHES "Darwin")

--- a/inputstream.ffmpegdirect/addon.xml.in
+++ b/inputstream.ffmpegdirect/addon.xml.in
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <addon
   id="inputstream.ffmpegdirect"
-  version="1.21.0"
+  version="1.21.1"
   name="Inputstream FFmpeg Direct"
   provider-name="Ross Nicholson">
   <requires>@ADDON_DEPENDS@</requires>
@@ -26,6 +26,10 @@
       <fanart>fanart.jpg</fanart>
     </assets>
     <news>
+v1.21.1
+- Fixed: remove workaround for ffmpeg deprecated function on windowsstore
+- Fixed: Replace deprecated av_init_packet() from ffmpeg
+
 v1.21.0
 - Update: FFmpeg to 4.4
 - Update: Update gas preprocessor for ffmpeg4.4

--- a/inputstream.ffmpegdirect/changelog.txt
+++ b/inputstream.ffmpegdirect/changelog.txt
@@ -1,3 +1,7 @@
+v1.21.1
+- Fixed: remove workaround for ffmpeg deprecated function on windowsstore
+- Fixed: Replace deprecated av_init_packet() from ffmpeg
+
 v1.21.0
 - Update: FFmpeg to 4.4
 - Update: Update gas preprocessor for ffmpeg4.4


### PR DESCRIPTION
v1.21.1
- Fixed: remove workaround for ffmpeg deprecated function on windowsstore
- Fixed: Replace deprecated av_init_packet() from ffmpeg