### PR TITLE
Allow timezone shift when live URLs have placeholders

### DIFF
--- a/inputstream.ffmpegdirect/addon.xml.in
+++ b/inputstream.ffmpegdirect/addon.xml.in
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <addon
   id="inputstream.ffmpegdirect"
-  version="1.21.1"
+  version="1.21.2"
   name="Inputstream FFmpeg Direct"
   provider-name="Ross Nicholson">
   <requires>@ADDON_DEPENDS@</requires>
@@ -26,6 +26,9 @@
       <fanart>fanart.jpg</fanart>
     </assets>
     <news>
+v1.21.2
+Fixed: Allow timezone shift when live URLs have placeholders
+
 v1.21.1
 - Fixed: remove workaround for ffmpeg deprecated function on windowsstore
 - Fixed: Replace deprecated av_init_packet() from ffmpeg

--- a/inputstream.ffmpegdirect/changelog.txt
+++ b/inputstream.ffmpegdirect/changelog.txt
@@ -1,3 +1,6 @@
+v1.21.2
+Fixed: Allow timezone shift when live URLs have placeholders
+
 v1.21.1
 - Fixed: remove workaround for ffmpeg deprecated function on windowsstore
 - Fixed: Replace deprecated av_init_packet() from ffmpeg

--- a/src/stream/FFmpegCatchupStream.cpp
+++ b/src/stream/FFmpegCatchupStream.cpp
@@ -503,10 +503,10 @@ std::string FormatDateTime(time_t timeStart, time_t duration, const std::string 
   return formattedUrl;
 }
 
-std::string FormatDateTimeNowOnly(const std::string &urlFormatString)
+std::string FormatDateTimeNowOnly(const std::string &urlFormatString, int timezoneShiftSecs)
 {
   std::string formattedUrl = urlFormatString;
-  const time_t timeNow = std::time(0);
+  const time_t timeNow = std::time(0) - timezoneShiftSecs;
   std::tm dateTimeNow = SafeLocaltime(timeNow);
 
   FormatUtc("{lutc}", timeNow, formattedUrl);
@@ -562,5 +562,5 @@ std::string FFmpegCatchupStream::GetUpdatedCatchupUrl() const
   }
 
   Log(LOGLEVEL_DEBUG, "%s - Default URL: %s", __FUNCTION__, CURL::GetRedacted(m_defaultUrl).c_str());
-  return FormatDateTimeNowOnly(m_defaultUrl);
+  return FormatDateTimeNowOnly(m_defaultUrl, m_timezoneShift);
 }


### PR DESCRIPTION
v1.21.2
Fixed: Allow timezone shift when live URLs have placeholders
