### PR TITLE
remove usage of kodi::tools::CEndTime

### DIFF
--- a/src/stream/FFmpegStream.h
+++ b/src/stream/FFmpegStream.h
@@ -14,6 +14,7 @@
 #include "DemuxStream.h"
 #include "CurlInput.h"
 
+#include <chrono>
 #include <iostream>
 #include <map>
 #include <memory>
@@ -22,7 +23,6 @@
 #include <sstream>
 
 #include <kodi/addon-instance/Inputstream.h>
-#include <kodi/tools/EndTime.h>
 
 #ifndef __GNUC__
 #pragma warning(push)
@@ -169,7 +169,8 @@ private:
   unsigned int m_initialProgramNumber;
   int m_seekStream;
 
-  kodi::tools::CEndTime  m_timeout;
+  std::chrono::steady_clock::time_point m_start;
+  std::chrono::milliseconds m_timeout;
 
   // Due to limitations of ffmpeg, we only can detect a program change
   // with a packet. This struct saves the packet for the next read and


### PR DESCRIPTION
This removes the usage of `kodi::tools::CEndTime` which should be deprecated from the add-on api.

I'm PRing this now as it shouldn't harm the Matrix branch but if desired when we branch I can update the targeted branch to the new `N` name.