### PR TITLE
Revert "fix hls bitrate selection" - berkhornet

### DIFF
--- a/src/stream/FFmpegStream.cpp
+++ b/src/stream/FFmpegStream.cpp
@@ -792,14 +792,9 @@ bool FFmpegStream::Open(bool fileinfo)
 
   // select the correct program if requested
   m_initialProgramNumber = UINT_MAX;
-  CVariant programProp;
-  if (!m_programProperty.empty())
-  {
-    CVariant programProp(m_programProperty);
-
-    if (!programProp.isNull() && programProp.isInteger())
-      m_initialProgramNumber = static_cast<int>(programProp.asInteger());
-  }
+  CVariant programProp(m_programProperty);
+  if (!programProp.isNull())
+    m_initialProgramNumber = static_cast<int>(programProp.asInteger());
 
   // in case of mpegts and we have not seen pat/pmt, defer creation of streams
   if (!skipCreateStreams || m_pFormatContext->nb_programs > 0)


### PR DESCRIPTION
This reverts commit 9780c141162ef7f5a50445a794beb1df44ade3d4.

Test PR raised in: https://github.com/kodi-pvr/pvr.iptvsimple/issues/524

Likely the fix hls bitrate fix chooses the highest quality stream which has issues with pause. The prior choice would have been a lower quality stream which did not.