### PR TITLE
Libxml2 update

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,1 +1,1 @@
-buildPlugin(version: "Nexus", UBUNTU_DISTS: ['focal'])
+buildPlugin(version: "Nexus", platforms: ["android-armv7", "android-aarch64", "ios-aarch64", "osx-x86_64", "tvos-aarch64", "ubuntu-ppa", "windows-i686", "windows-x86_64"], UBUNTU_DISTS: ['focal'])

--- a/depends/common/libxml2/libxml2.txt
+++ b/depends/common/libxml2/libxml2.txt
@@ -1,1 +1,1 @@
-libxml2 http://xmlsoft.org/sources/libxml2-2.9.10.tar.gz
+libxml2 http://mirrors.kodi.tv/build-deps/sources/libxml2-2.9.10.tar.gz

--- a/inputstream.ffmpegdirect/addon.xml.in
+++ b/inputstream.ffmpegdirect/addon.xml.in
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <addon
   id="inputstream.ffmpegdirect"
-  version="20.2.1"
+  version="20.2.2"
   name="Inputstream FFmpeg Direct"
   provider-name="Ross Nicholson">
   <requires>@ADDON_DEPENDS@</requires>

--- a/inputstream.ffmpegdirect/changelog.txt
+++ b/inputstream.ffmpegdirect/changelog.txt
@@ -1,3 +1,7 @@
+v20.2.2
+- Update source URL to kodi mirror
+- Exclude osx-arm64 from Jenkins builds
+
 v20.2.1
 - Update azure windows image to windows-2019 that uses VS201
 - Fix ffmpeg configure option for Android


### PR DESCRIPTION
v20.2.2
- Update source URL to kodi mirror
- Exclude osx-arm64 from Jenkins builds