### PR TITLE
Updated SetVideoResolution due to api change

### DIFF
--- a/inputstream.ffmpegdirect/addon.xml.in
+++ b/inputstream.ffmpegdirect/addon.xml.in
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <addon
   id="inputstream.ffmpegdirect"
-  version="20.4.0"
+  version="20.5.0"
   name="Inputstream FFmpeg Direct"
   provider-name="Ross Nicholson">
   <requires>@ADDON_DEPENDS@</requires>

--- a/inputstream.ffmpegdirect/changelog.txt
+++ b/inputstream.ffmpegdirect/changelog.txt
@@ -1,3 +1,6 @@
+v20.5.0
+- Kodi inputstream API update to version 3.2.0
+
 v20.4.0
 - Support osx-arm64, i.e. OSX on Apple Silicon
 

--- a/src/StreamManager.cpp
+++ b/src/StreamManager.cpp
@@ -285,7 +285,7 @@ void InputStreamFFmpegDirect::DemuxSetSpeed(int speed)
   m_stream->DemuxSetSpeed(speed);
 }
 
-void InputStreamFFmpegDirect::SetVideoResolution(int width, int height)
+void InputStreamFFmpegDirect::SetVideoResolution(unsigned int width, unsigned int height)
 {
   Log(LOGLEVEL_DEBUG, "inputstream.ffmpegdirect: SetVideoResolution()");
 

--- a/src/StreamManager.h
+++ b/src/StreamManager.h
@@ -57,7 +57,7 @@ public:
   virtual DEMUX_PACKET* DemuxRead() override;
   virtual bool DemuxSeekTime(double time, bool backwards, double& startpts) override;
   virtual void DemuxSetSpeed(int speed) override;
-  virtual void SetVideoResolution(int width, int height) override;
+  virtual void SetVideoResolution(unsigned int width, unsigned int height) override;
 
   virtual int GetTotalTime() override;
   virtual int GetTime() override;
@@ -90,8 +90,8 @@ private:
 
   ffmpegdirect::Properties m_properties;
 
-  int m_videoWidth;
-  int m_videoHeight;
+  unsigned int m_videoWidth;
+  unsigned int m_videoHeight;
 
   std::shared_ptr<ffmpegdirect::BaseStream> m_stream;
 };

--- a/src/stream/BaseStream.h
+++ b/src/stream/BaseStream.h
@@ -36,7 +36,7 @@ public:
   virtual DEMUX_PACKET* DemuxRead() = 0;
   virtual bool DemuxSeekTime(double time, bool backwards, double& startpts) = 0;
   virtual void DemuxSetSpeed(int speed) = 0;
-  virtual void SetVideoResolution(int width, int height) = 0;
+  virtual void SetVideoResolution(unsigned int width, unsigned int height) = 0;
 
   virtual int GetTotalTime() = 0;
   virtual int GetTime() = 0;

--- a/src/stream/FFmpegStream.cpp
+++ b/src/stream/FFmpegStream.cpp
@@ -536,7 +536,7 @@ void FFmpegStream::DemuxSetSpeed(int speed)
   }
 }
 
-void FFmpegStream::SetVideoResolution(int width, int height)
+void FFmpegStream::SetVideoResolution(unsigned int width, unsigned int height)
 {
 
 }

--- a/src/stream/FFmpegStream.h
+++ b/src/stream/FFmpegStream.h
@@ -75,7 +75,7 @@ public:
   virtual DEMUX_PACKET* DemuxRead() override;
   virtual bool DemuxSeekTime(double time, bool backwards, double& startpts) override;
   virtual void DemuxSetSpeed(int speed) override;
-  virtual void SetVideoResolution(int width, int height) override;
+  virtual void SetVideoResolution(unsigned int width, unsigned int height) override;
 
   virtual int GetTotalTime() override;// { return 20; }
   virtual int GetTime() override;// { return m_displayTime; }


### PR DESCRIPTION
This update the SetVideoResolution method of InputStream interface,
that now use `unsigned int` variables

**this depends from:** https://github.com/xbmc/xbmc/pull/21319
