### PR TITLE
Allow ffmpeg header "cenc_decryption_key"

### DIFF
--- a/src/stream/FFmpegStream.cpp
+++ b/src/stream/FFmpegStream.cpp
@@ -2230,7 +2230,7 @@ AVDictionary* FFmpegStream::GetFFMpegOptionsFromInput()
       // set any of these ffmpeg options
       if (name == "seekable" || name == "reconnect" || name == "reconnect_at_eof" ||
           name == "reconnect_streamed" || name == "reconnect_delay_max" ||
-          name == "icy" || name == "icy_metadata_headers" || name == "icy_metadata_packet")
+          name == "icy" || name == "icy_metadata_headers" || name == "icy_metadata_packet" || name == "cenc_decryption_key")
       {
         Log(LOGLEVEL_DEBUG,
                   "CDVDDemuxFFmpeg::GetFFMpegOptionsFromInput() adding ffmpeg option '%s: %s'",


### PR DESCRIPTION
Tested on Kodi 20.0-RC2 (19.90.905) (x86-64 linux) also tested on Android (armv7)

Can be tested using public mpd link's and key (There are some at https://bitmovin.com/demos/drm)

third time's time charm