### PR TITLE
include missing <cstdint> to support gcc-13

### DIFF
--- a/src/utils/DiskUtils.h
+++ b/src/utils/DiskUtils.h
@@ -7,6 +7,7 @@
 
 #pragma once
 
+#include <cstdint>
 #include <string>
 
 namespace ffmpegdirect

--- a/src/utils/HttpProxy.h
+++ b/src/utils/HttpProxy.h
@@ -7,6 +7,7 @@
 
 #pragma once
 
+#include <cstdint>
 #include <string>
 
 namespace ffmpegdirect


### PR DESCRIPTION
gcc 13 moved some includes around and as a result <cstdint> is no longer transitively included [1]. Explicitly include it for uint{32,64}_t.

[1] https://gcc.gnu.org/gcc-13/porting_to.html#header-dep-changes