### PR TITLE
Fix seeking in FFmpegDirect caused by st->cur_pts replacement

### DIFF
--- a/src/stream/FFmpegCatchupStream.cpp
+++ b/src/stream/FFmpegCatchupStream.cpp
@@ -362,13 +362,6 @@ bool FFmpegCatchupStream::GetTimes(kodi::addon::InputstreamTimes& times)
   return true;
 }
 
-void FFmpegCatchupStream::UpdateCurrentPTS()
-{
-  FFmpegStream::UpdateCurrentPTS();
-  if (m_currentPts != STREAM_NOPTS_VALUE)
-    m_currentPts += m_seekOffset;
-}
-
 bool FFmpegCatchupStream::IsRealTimeStream()
 {
   if (kodi::addon::GetSettingBoolean("forceRealtimeOffCatchup"))

--- a/src/stream/FFmpegCatchupStream.h
+++ b/src/stream/FFmpegCatchupStream.h
@@ -43,7 +43,6 @@ public:
   virtual bool IsRealTimeStream() override;
 
 protected:
-  void UpdateCurrentPTS() override;
   bool CheckReturnEmptyOnPacketResult(int result) override;
 
   long long GetCurrentLiveOffset() { return std::time(nullptr) - m_catchupBufferStartTime; }

--- a/src/stream/FFmpegStream.cpp
+++ b/src/stream/FFmpegStream.cpp
@@ -1733,9 +1733,6 @@ TRANSPORT_STREAM_STATE FFmpegStream::TransportStreamAudioState()
     for (unsigned int i = 0; i < m_pFormatContext->programs[m_program]->nb_stream_indexes; i++)
     {
       int idx = m_pFormatContext->programs[m_program]->stream_index[i];
-      // if we match m_seekStream then we are ready
-      if (idx == m_seekStream)
-        return TRANSPORT_STREAM_STATE::READY;
       st = m_pFormatContext->streams[idx];
       if (st->codecpar->codec_type == AVMEDIA_TYPE_AUDIO)
       {
@@ -1756,9 +1753,6 @@ TRANSPORT_STREAM_STATE FFmpegStream::TransportStreamAudioState()
   {
     for (unsigned int i = 0; i < m_pFormatContext->nb_streams; i++)
     {
-      // if we match m_seekStream then we are ready
-      if (static_cast<int>(i) == m_seekStream)
-        return TRANSPORT_STREAM_STATE::READY;
       st = m_pFormatContext->streams[i];
       if (st->codecpar->codec_type == AVMEDIA_TYPE_AUDIO)
       {
@@ -1775,6 +1769,8 @@ TRANSPORT_STREAM_STATE FFmpegStream::TransportStreamAudioState()
       }
     }
   }
+  if (hasAudio && m_startTime)
+    return TRANSPORT_STREAM_STATE::READY;
 
   return (hasAudio) ? TRANSPORT_STREAM_STATE::NOTREADY : TRANSPORT_STREAM_STATE::NONE;
 }
@@ -1792,9 +1788,6 @@ TRANSPORT_STREAM_STATE FFmpegStream::TransportStreamVideoState()
     for (unsigned int i = 0; i < m_pFormatContext->programs[m_program]->nb_stream_indexes; i++)
     {
       int idx = m_pFormatContext->programs[m_program]->stream_index[i];
-      // if we match m_seekStream then we are ready
-      if (idx == m_seekStream)
-        return TRANSPORT_STREAM_STATE::READY;
       st = m_pFormatContext->streams[idx];
       if (st->codecpar->codec_type == AVMEDIA_TYPE_VIDEO)
       {
@@ -1816,9 +1809,6 @@ TRANSPORT_STREAM_STATE FFmpegStream::TransportStreamVideoState()
   {
     for (unsigned int i = 0; i < m_pFormatContext->nb_streams; i++)
     {
-      // if we match m_seekStream then we are ready
-      if (static_cast<int>(i) == m_seekStream)
-        return TRANSPORT_STREAM_STATE::READY;
       st = m_pFormatContext->streams[i];
       if (st->codecpar->codec_type == AVMEDIA_TYPE_VIDEO)
       {
@@ -1835,6 +1825,8 @@ TRANSPORT_STREAM_STATE FFmpegStream::TransportStreamVideoState()
       }
     }
   }
+  if (hasVideo && m_startTime)
+    return TRANSPORT_STREAM_STATE::READY;
 
   return (hasVideo) ? TRANSPORT_STREAM_STATE::NOTREADY : TRANSPORT_STREAM_STATE::NONE;
 }

--- a/src/stream/FFmpegStream.cpp
+++ b/src/stream/FFmpegStream.cpp
@@ -1737,9 +1737,9 @@ TRANSPORT_STREAM_STATE FFmpegStream::TransportStreamAudioState()
       if (idx == m_seekStream)
         return TRANSPORT_STREAM_STATE::READY;
       st = m_pFormatContext->streams[idx];
-      if (st->codecpar->codec_type == AVMEDIA_TYPE_AUDIO && idx == m_pkt.pkt.stream_index)
+      if (st->codecpar->codec_type == AVMEDIA_TYPE_AUDIO)
       {
-        if (m_pkt.pkt.dts != AV_NOPTS_VALUE)
+        if (idx == m_pkt.pkt.stream_index && m_pkt.pkt.dts != AV_NOPTS_VALUE)
         {
           if (!m_startTime)
           {
@@ -1760,10 +1760,9 @@ TRANSPORT_STREAM_STATE FFmpegStream::TransportStreamAudioState()
       if (static_cast<int>(i) == m_seekStream)
         return TRANSPORT_STREAM_STATE::READY;
       st = m_pFormatContext->streams[i];
-      if (st->codecpar->codec_type == AVMEDIA_TYPE_AUDIO &&
-          static_cast<int>(i) == m_pkt.pkt.stream_index)
+      if (st->codecpar->codec_type == AVMEDIA_TYPE_AUDIO)
       {
-        if (m_pkt.pkt.dts != AV_NOPTS_VALUE)
+        if (static_cast<int>(i) == m_pkt.pkt.stream_index && m_pkt.pkt.dts != AV_NOPTS_VALUE)
         {
           if (!m_startTime)
           {
@@ -1797,9 +1796,10 @@ TRANSPORT_STREAM_STATE FFmpegStream::TransportStreamVideoState()
       if (idx == m_seekStream)
         return TRANSPORT_STREAM_STATE::READY;
       st = m_pFormatContext->streams[idx];
-      if (st->codecpar->codec_type == AVMEDIA_TYPE_VIDEO && idx == m_pkt.pkt.stream_index)
+      if (st->codecpar->codec_type == AVMEDIA_TYPE_VIDEO)
       {
-        if (m_pkt.pkt.dts != AV_NOPTS_VALUE && st->codecpar->extradata)
+        if (idx == m_pkt.pkt.stream_index && m_pkt.pkt.dts != AV_NOPTS_VALUE &&
+            st->codecpar->extradata)
         {
           if (!m_startTime)
           {
@@ -1820,11 +1820,10 @@ TRANSPORT_STREAM_STATE FFmpegStream::TransportStreamVideoState()
       if (static_cast<int>(i) == m_seekStream)
         return TRANSPORT_STREAM_STATE::READY;
       st = m_pFormatContext->streams[i];
-      if (st->codecpar->codec_type == AVMEDIA_TYPE_VIDEO &&
-          static_cast<int>(i) == m_pkt.pkt.stream_index)
+      if (st->codecpar->codec_type == AVMEDIA_TYPE_VIDEO)
       {
-        if (m_pkt.pkt.dts != AV_NOPTS_VALUE && st->codecpar->extradata)
-        {
+        if (static_cast<int>(i) == m_pkt.pkt.stream_index && m_pkt.pkt.dts != AV_NOPTS_VALUE &&
+            st->codecpar->extradata)
           if (!m_startTime)
           {
             m_startTime = av_rescale(m_pkt.pkt.dts, st->time_base.num, st->time_base.den) - 0.000001;

--- a/src/stream/FFmpegStream.cpp
+++ b/src/stream/FFmpegStream.cpp
@@ -1753,10 +1753,13 @@ TRANSPORT_STREAM_STATE FFmpegStream::TransportStreamAudioState()
     for (unsigned int i = 0; i < m_pFormatContext->programs[m_program]->nb_stream_indexes; i++)
     {
       int idx = m_pFormatContext->programs[m_program]->stream_index[i];
+      // if we match m_seekStream then we are ready
+      if (idx == m_seekStream)
+        return TRANSPORT_STREAM_STATE::READY;
       st = m_pFormatContext->streams[idx];
-      if (st->codecpar->codec_type == AVMEDIA_TYPE_AUDIO)
+      if (st->codecpar->codec_type == AVMEDIA_TYPE_AUDIO && idx == m_pkt.pkt.stream_index)
       {
-        if (st->start_time != AV_NOPTS_VALUE)
+        if (m_pkt.pkt.dts != AV_NOPTS_VALUE)
         {
           if (!m_startTime)
           {
@@ -1773,10 +1776,14 @@ TRANSPORT_STREAM_STATE FFmpegStream::TransportStreamAudioState()
   {
     for (unsigned int i = 0; i < m_pFormatContext->nb_streams; i++)
     {
+      // if we match m_seekStream then we are ready
+      if (static_cast<int>(i) == m_seekStream)
+        return TRANSPORT_STREAM_STATE::READY;
       st = m_pFormatContext->streams[i];
-      if (st->codecpar->codec_type == AVMEDIA_TYPE_AUDIO)
+      if (st->codecpar->codec_type == AVMEDIA_TYPE_AUDIO &&
+          static_cast<int>(i) == m_pkt.pkt.stream_index)
       {
-        if (st->start_time != AV_NOPTS_VALUE)
+        if (m_pkt.pkt.dts != AV_NOPTS_VALUE)
         {
           if (!m_startTime)
           {
@@ -1806,10 +1813,13 @@ TRANSPORT_STREAM_STATE FFmpegStream::TransportStreamVideoState()
     for (unsigned int i = 0; i < m_pFormatContext->programs[m_program]->nb_stream_indexes; i++)
     {
       int idx = m_pFormatContext->programs[m_program]->stream_index[i];
+      // if we match m_seekStream then we are ready
+      if (idx == m_seekStream)
+        return TRANSPORT_STREAM_STATE::READY;
       st = m_pFormatContext->streams[idx];
-      if (st->codecpar->codec_type == AVMEDIA_TYPE_VIDEO)
+      if (st->codecpar->codec_type == AVMEDIA_TYPE_VIDEO && idx == m_pkt.pkt.stream_index)
       {
-        if (st->codecpar->extradata)
+        if (m_pkt.pkt.dts != AV_NOPTS_VALUE && st->codecpar->extradata)
         {
           if (!m_startTime)
           {
@@ -1826,10 +1836,14 @@ TRANSPORT_STREAM_STATE FFmpegStream::TransportStreamVideoState()
   {
     for (unsigned int i = 0; i < m_pFormatContext->nb_streams; i++)
     {
+      // if we match m_seekStream then we are ready
+      if (static_cast<int>(i) == m_seekStream)
+        return TRANSPORT_STREAM_STATE::READY;
       st = m_pFormatContext->streams[i];
-      if (st->codecpar->codec_type == AVMEDIA_TYPE_VIDEO)
+      if (st->codecpar->codec_type == AVMEDIA_TYPE_VIDEO &&
+          static_cast<int>(i) == m_pkt.pkt.stream_index)
       {
-        if (st->codecpar->extradata)
+        if (m_pkt.pkt.dts != AV_NOPTS_VALUE && st->codecpar->extradata)
         {
           if (!m_startTime)
           {

--- a/src/stream/FFmpegStream.h
+++ b/src/stream/FFmpegStream.h
@@ -104,7 +104,6 @@ public:
 
 protected:
   virtual std::string GetStreamCodecName(int iStreamId);
-  virtual void UpdateCurrentPTS();
   bool IsPaused() { return m_speed == STREAM_PLAYSPEED_PAUSE; }
   virtual bool CheckReturnEmptyOnPacketResult(int result);
 


### PR DESCRIPTION
Based off changes in Kodi PR: https://github.com/xbmc/xbmc/pull/23557/commits and https://github.com/xbmc/xbmc/pull/23629/commits

The first commit is ok. The second required removing `UpdateCurrentPTS()` which is used for catchup support. Need a better solution for doing the offset for catchup streams.

Commits 3,4 and 5 are followups and also OK. 

TL;DR; fix commit 2