### PR TITLE
Fix seeking in FFmpegDirect caused by st->cur_pts replacement in FFmpeg6 and Synchronise code with Kodi up to end of 2023

### DIFF
--- a/inputstream.ffmpegdirect/addon.xml.in
+++ b/inputstream.ffmpegdirect/addon.xml.in
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <addon
   id="inputstream.ffmpegdirect"
-  version="21.2.1"
+  version="21.3.0"
   name="Inputstream FFmpeg Direct"
   provider-name="Ross Nicholson">
   <requires>@ADDON_DEPENDS@</requires>

--- a/inputstream.ffmpegdirect/changelog.txt
+++ b/inputstream.ffmpegdirect/changelog.txt
@@ -1,3 +1,7 @@
+v21.3.0
+- Fix seeking in FFmpegDirect caused by st->cur_pts replacement in FFmpeg6
+- Sync FFmpegStream.cpp and DemuxStream.cpp with xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemuxFFmpeg.cpp from https://github.com/xbmc/xbmc. Update for all commits up to the end of 2023
+
 v21.2.1
 - Update dependency xz-utils to version 5.4.3
 - Update dependency zlib to version 1.2.13

--- a/src/stream/DemuxStream.cpp
+++ b/src/stream/DemuxStream.cpp
@@ -180,8 +180,10 @@ DemuxParserFFmpeg::~DemuxParserFFmpeg()
 }
 
 FFmpegExtraData::FFmpegExtraData(size_t size)
-  : m_data(reinterpret_cast<uint8_t*>(av_malloc(size + AV_INPUT_BUFFER_PADDING_SIZE))), m_size(size)
+  : m_data(reinterpret_cast<uint8_t*>(av_mallocz(size + AV_INPUT_BUFFER_PADDING_SIZE))),
+    m_size(size)
 {
+  // using av_mallocz because some APIs require at least the padding to be zeroed, e.g. AVCodecParameters
   if (!m_data)
     throw std::bad_alloc();
 }

--- a/src/stream/DemuxStream.cpp
+++ b/src/stream/DemuxStream.cpp
@@ -244,3 +244,11 @@ bool FFmpegExtraData::operator!=(const FFmpegExtraData& other) const
 {
   return !(*this == other);
 }
+
+uint8_t* FFmpegExtraData::TakeData()
+{
+  auto tmp = m_data;
+  m_data = nullptr;
+  m_size = 0;
+  return tmp;
+}

--- a/src/stream/DemuxStream.h
+++ b/src/stream/DemuxStream.h
@@ -112,6 +112,7 @@ public:
   int iOrientation = 0; // orientation of the video in degrees counter clockwise
   int iBitsPerPixel = 0;
   int iBitRate = 0;
+  int iBitDepth = 0;
 
   AVColorSpace colorSpace = AVCOL_SPC_UNSPECIFIED;
   AVColorRange colorRange = AVCOL_RANGE_UNSPECIFIED;

--- a/src/stream/DemuxStream.h
+++ b/src/stream/DemuxStream.h
@@ -22,6 +22,7 @@
 extern "C"
 {
 #include <libavcodec/avcodec.h>
+#include <libavutil/dovi_meta.h>
 #include <libavformat/avformat.h>
 #include <libavutil/mastering_display_metadata.h>
 }
@@ -122,6 +123,7 @@ public:
   std::shared_ptr<AVContentLightMetadata> contentLightMetaData;
 
   std::string stereo_mode; // expected stereo mode
+  AVDOVIDecoderConfigurationRecord dovi{};
   StreamHdrType hdr_type = StreamHdrType::HDR_TYPE_NONE; // type of HDR for this stream (hdr10, etc)
 };
 

--- a/src/stream/DemuxStream.h
+++ b/src/stream/DemuxStream.h
@@ -34,6 +34,34 @@ extern "C"
 namespace ffmpegdirect
 {
 
+
+class FFmpegExtraData
+{
+public:
+  FFmpegExtraData() = default;
+  explicit FFmpegExtraData(size_t size);
+  FFmpegExtraData(const uint8_t* data, size_t size);
+  FFmpegExtraData(const FFmpegExtraData& other);
+  FFmpegExtraData(FFmpegExtraData&& other) noexcept;
+
+  ~FFmpegExtraData();
+
+  FFmpegExtraData& operator=(const FFmpegExtraData& other);
+  FFmpegExtraData& operator=(FFmpegExtraData&& other) noexcept;
+
+  bool operator==(const FFmpegExtraData& other) const;
+  bool operator!=(const FFmpegExtraData& other) const;
+
+  operator bool() const { return m_data != nullptr && m_size != 0; }
+  uint8_t* GetData() { return m_data; }
+  const uint8_t* GetData() const { return m_data; }
+  size_t GetSize() const { return m_size; }
+
+private:
+  uint8_t* m_data{nullptr};
+  size_t m_size{};
+};
+
 class DemuxStream
 {
 public:
@@ -48,14 +76,13 @@ public:
     type = INPUTSTREAM_TYPE_NONE;
     iDuration = 0;
     pPrivate = NULL;
-    ExtraData = NULL;
-    ExtraSize = 0;
     disabled = false;
     changes = 0;
     flags = INPUTSTREAM_FLAG_NONE;
   }
 
-  virtual ~DemuxStream() { delete[] ExtraData; }
+  virtual ~DemuxStream() = default;
+  DemuxStream(DemuxStream&&) = default;
 
   virtual std::string GetStreamName();
   virtual bool GetInformation(kodi::addon::InputstreamInfo& info);
@@ -71,8 +98,7 @@ public:
 
   int iDuration; // in mseconds
   void* pPrivate; // private pointer for the demuxer
-  uint8_t* ExtraData; // extra data for codec to use
-  unsigned int ExtraSize; // size of extra data
+  FFmpegExtraData extraData;
 
   INPUTSTREAM_FLAGS flags;
   std::string language; // RFC 5646 language code (empty string if undefined)

--- a/src/stream/DemuxStream.h
+++ b/src/stream/DemuxStream.h
@@ -86,6 +86,14 @@ public:
   std::shared_ptr<kodi::addon::StreamCryptoSession> cryptoSession;
 };
 
+enum class StreamHdrType
+{
+  HDR_TYPE_NONE, ///< <b>None</b>, returns an empty string when used in infolabels
+  HDR_TYPE_HDR10, ///< <b>HDR10</b>, returns `hdr10` when used in infolabels
+  HDR_TYPE_DOLBYVISION, ///< <b>Dolby Vision</b>, returns `dolbyvision` when used in infolabels
+  HDR_TYPE_HLG ///< <b>HLG</b>, returns `hlg` when used in infolabels
+};
+
 class DemuxStreamVideo : public DemuxStream
 {
 public:
@@ -114,6 +122,7 @@ public:
   std::shared_ptr<AVContentLightMetadata> contentLightMetaData;
 
   std::string stereo_mode; // expected stereo mode
+  StreamHdrType hdr_type = StreamHdrType::HDR_TYPE_NONE; // type of HDR for this stream (hdr10, etc)
 };
 
 class DemuxStreamAudio : public DemuxStream

--- a/src/stream/DemuxStream.h
+++ b/src/stream/DemuxStream.h
@@ -41,7 +41,6 @@ public:
     uniqueId = 0;
     dvdNavId = 0;
     demuxerId = -1;
-    codec = (AVCodecID)0; // AV_CODEC_ID_NONE
     codec_fourcc = 0;
     profile = FF_PROFILE_UNKNOWN;
     level = FF_LEVEL_UNKNOWN;
@@ -63,7 +62,7 @@ public:
   int uniqueId; // unique stream id
   int dvdNavId;
   int64_t demuxerId; // id of the associated demuxer
-  AVCodecID codec;
+  AVCodecID codec = AV_CODEC_ID_NONE;
   unsigned int codec_fourcc; // if available
   int profile; // encoder profile of the stream reported by the decoder. used to qualify hw decoders.
   int level; // encoder level of the stream reported by the decoder. used to qualify hw decoders.

--- a/src/stream/DemuxStream.h
+++ b/src/stream/DemuxStream.h
@@ -56,6 +56,15 @@ public:
   uint8_t* GetData() { return m_data; }
   const uint8_t* GetData() const { return m_data; }
   size_t GetSize() const { return m_size; }
+  /*!
+   * \brief Take ownership over the extra data buffer
+   *
+   * It's in the responsibility of the caller to free the buffer with av_free. After the call
+   * FFmpegExtraData is empty.
+   *
+   * \return The extra data buffer or nullptr if FFmpegExtraData is empty.
+   */
+  uint8_t* TakeData();
 
 private:
   uint8_t* m_data{nullptr};

--- a/src/stream/DemuxStream.h
+++ b/src/stream/DemuxStream.h
@@ -138,6 +138,7 @@ public:
 
   int iFpsScale = 0; // scale of 1000 and a rate of 29970 will result in 29.97 fps
   int iFpsRate = 0;
+  bool bInterlaced = false; // unknown or progressive => false, otherwise true.
   int iHeight = 0; // height of the stream reported by the demuxer
   int iWidth = 0; // width of the stream reported by the demuxer
   double fAspect = 0; // display aspect of stream

--- a/src/stream/FFmpegCatchupStream.cpp
+++ b/src/stream/FFmpegCatchupStream.cpp
@@ -362,9 +362,9 @@ bool FFmpegCatchupStream::GetTimes(kodi::addon::InputstreamTimes& times)
   return true;
 }
 
-void FFmpegCatchupStream::UpdateCurrentPTS()
+void FFmpegCatchupStream::CurrentPTSUpdated()
 {
-  FFmpegStream::UpdateCurrentPTS();
+  FFmpegStream::CurrentPTSUpdated();
   if (m_currentPts != STREAM_NOPTS_VALUE)
     m_currentPts += m_seekOffset;
 }

--- a/src/stream/FFmpegCatchupStream.h
+++ b/src/stream/FFmpegCatchupStream.h
@@ -43,7 +43,7 @@ public:
   virtual bool IsRealTimeStream() override;
 
 protected:
-  void UpdateCurrentPTS() override;
+  void CurrentPTSUpdated() override;
   bool CheckReturnEmptyOnPacketResult(int result) override;
 
   long long GetCurrentLiveOffset() { return std::time(nullptr) - m_catchupBufferStartTime; }

--- a/src/stream/FFmpegStream.cpp
+++ b/src/stream/FFmpegStream.cpp
@@ -1772,9 +1772,9 @@ TRANSPORT_STREAM_STATE FFmpegStream::TransportStreamAudioState()
       if (idx == m_seekStream)
         return TRANSPORT_STREAM_STATE::READY;
       st = m_pFormatContext->streams[idx];
-      if (st->codecpar->codec_type == AVMEDIA_TYPE_AUDIO && idx == m_pkt.pkt.stream_index)
+      if (st->codecpar->codec_type == AVMEDIA_TYPE_AUDIO)
       {
-        if (m_pkt.pkt.dts != AV_NOPTS_VALUE)
+        if (idx == m_pkt.pkt.stream_index && m_pkt.pkt.dts != AV_NOPTS_VALUE)
         {
           if (!m_startTime)
           {
@@ -1795,10 +1795,9 @@ TRANSPORT_STREAM_STATE FFmpegStream::TransportStreamAudioState()
       if (static_cast<int>(i) == m_seekStream)
         return TRANSPORT_STREAM_STATE::READY;
       st = m_pFormatContext->streams[i];
-      if (st->codecpar->codec_type == AVMEDIA_TYPE_AUDIO &&
-          static_cast<int>(i) == m_pkt.pkt.stream_index)
+      if (st->codecpar->codec_type == AVMEDIA_TYPE_AUDIO)
       {
-        if (m_pkt.pkt.dts != AV_NOPTS_VALUE)
+        if (static_cast<int>(i) == m_pkt.pkt.stream_index && m_pkt.pkt.dts != AV_NOPTS_VALUE)
         {
           if (!m_startTime)
           {
@@ -1832,9 +1831,10 @@ TRANSPORT_STREAM_STATE FFmpegStream::TransportStreamVideoState()
       if (idx == m_seekStream)
         return TRANSPORT_STREAM_STATE::READY;
       st = m_pFormatContext->streams[idx];
-      if (st->codecpar->codec_type == AVMEDIA_TYPE_VIDEO && idx == m_pkt.pkt.stream_index)
+      if (st->codecpar->codec_type == AVMEDIA_TYPE_VIDEO)
       {
-        if (m_pkt.pkt.dts != AV_NOPTS_VALUE && st->codecpar->extradata)
+        if (idx == m_pkt.pkt.stream_index && m_pkt.pkt.dts != AV_NOPTS_VALUE &&
+            st->codecpar->extradata)
         {
           if (!m_startTime)
           {
@@ -1855,10 +1855,10 @@ TRANSPORT_STREAM_STATE FFmpegStream::TransportStreamVideoState()
       if (static_cast<int>(i) == m_seekStream)
         return TRANSPORT_STREAM_STATE::READY;
       st = m_pFormatContext->streams[i];
-      if (st->codecpar->codec_type == AVMEDIA_TYPE_VIDEO &&
-          static_cast<int>(i) == m_pkt.pkt.stream_index)
+      if (st->codecpar->codec_type == AVMEDIA_TYPE_VIDEO)
       {
-        if (m_pkt.pkt.dts != AV_NOPTS_VALUE && st->codecpar->extradata)
+        if (static_cast<int>(i) == m_pkt.pkt.stream_index && m_pkt.pkt.dts != AV_NOPTS_VALUE &&
+            st->codecpar->extradata)
         {
           if (!m_startTime)
           {

--- a/src/stream/FFmpegStream.cpp
+++ b/src/stream/FFmpegStream.cpp
@@ -720,13 +720,17 @@ bool FFmpegStream::Open(bool fileinfo)
 
   bool skipCreateStreams = false;
   bool isBluray = false;
-  if (iformat && (strcmp(iformat->name, "mpegts") == 0) && !fileinfo && !isBluray)
+  // don't re-open mpegts streams with hevc encoding as the params are not correctly detected again
+  if (iformat && (strcmp(iformat->name, "mpegts") == 0) && !fileinfo && !isBluray &&
+      m_pFormatContext->streams[0]->codecpar->codec_id != AV_CODEC_ID_HEVC)
   {
     av_opt_set_int(m_pFormatContext, "analyzeduration", 500000, 0);
     m_checkTransportStream = true;
     skipCreateStreams = true;
   }
-  else if (!iformat || (strcmp(iformat->name, "mpegts") != 0))
+  else if (!iformat || ((strcmp(iformat->name, "mpegts") != 0) ||
+           ((strcmp(iformat->name, "mpegts") == 0) &&
+            m_pFormatContext->streams[0]->codecpar->codec_id == AV_CODEC_ID_HEVC)))
   {
     m_streaminfo = true;
   }
@@ -2021,11 +2025,26 @@ DemuxStream* FFmpegStream::AddStream(int streamIdx)
         size_t size = 0;
         uint8_t* side_data = nullptr;
 
+        side_data = av_stream_get_side_data(pStream, AV_PKT_DATA_DOVI_CONF, &size);
+        if (side_data && size)
+          st->hdr_type = StreamHdrType::HDR_TYPE_DOLBYVISION;
+        else if (st->colorPrimaries == AVCOL_PRI_BT2020)
+        {
+          if (st->colorTransferCharacteristic == AVCOL_TRC_SMPTE2084) // hdr10
+            st->hdr_type = StreamHdrType::HDR_TYPE_HDR10;
+          else if (st->colorTransferCharacteristic == AVCOL_TRC_ARIB_STD_B67) // hlg
+            st->hdr_type = StreamHdrType::HDR_TYPE_HLG;
+        }
+
         side_data = av_stream_get_side_data(pStream, AV_PKT_DATA_MASTERING_DISPLAY_METADATA, &size);
         if (side_data && size)
         {
           st->masteringMetaData = std::make_shared<AVMasteringDisplayMetadata>(
               *reinterpret_cast<AVMasteringDisplayMetadata*>(side_data));
+          // file could be SMPTE2086 which FFmpeg currently returns as unknown so use the presence
+          // of static metadata to detect it
+          if (st->masteringMetaData->has_primaries && st->masteringMetaData->has_luminance)
+            st->hdr_type = StreamHdrType::HDR_TYPE_HDR10;
         }
 
         side_data = av_stream_get_side_data(pStream, AV_PKT_DATA_CONTENT_LIGHT_LEVEL, &size);

--- a/src/stream/FFmpegStream.cpp
+++ b/src/stream/FFmpegStream.cpp
@@ -1431,7 +1431,7 @@ void FFmpegStream::StoreSideData(DEMUX_PACKET *pkt, AVPacket *src)
     pkt->pSideData = avPkt->side_data;
     pkt->iSideDataElems = avPkt->side_data_elems;
 
-    //! @todo: properly handle avpkt side_data. this works around our inproper use of the side_data
+    //! @todo: properly handle avpkt side_data. this works around our improper use of the side_data
     // as we pass pointers to ffmpeg allocated memory for the side_data. we should really be allocating
     // and storing our own AVPacket. This will require some extensive changes.
     // tl;dr: it frees the packet but not the side data.
@@ -2095,7 +2095,7 @@ DemuxStream* FFmpegStream::AddStream(int streamIdx)
           }
           else
           {
-            // Note: libass only supports a single font directory to look for aditional fonts
+            // Note: libass only supports a single font directory to look for additional fonts
             // (c.f. ass_set_fonts_dir). To support both user defined fonts (those placed in
             // special://home/media/Fonts/) and fonts extracted by the demuxer, make it extract
             // fonts to the user directory with a known, easy to identify, prefix (tmp.font.*).

--- a/src/stream/FFmpegStream.cpp
+++ b/src/stream/FFmpegStream.cpp
@@ -80,9 +80,9 @@ bool AttachmentIsFont(const AVDictionaryEntry* dict)
   if (dict)
   {
     const std::string mimeType = dict->value;
-    return std::find_if(font_mimetypes.begin(), font_mimetypes.end(), [&mimeType](std::string str) {
-             return str == mimeType;
-           }) != font_mimetypes.end();
+    return std::find_if(font_mimetypes.begin(), font_mimetypes.end(),
+                        [&mimeType](std::string str) { return str == mimeType; }) !=
+           font_mimetypes.end();
   }
   return false;
 }

--- a/src/stream/FFmpegStream.cpp
+++ b/src/stream/FFmpegStream.cpp
@@ -1768,10 +1768,13 @@ TRANSPORT_STREAM_STATE FFmpegStream::TransportStreamAudioState()
     for (unsigned int i = 0; i < m_pFormatContext->programs[m_program]->nb_stream_indexes; i++)
     {
       int idx = m_pFormatContext->programs[m_program]->stream_index[i];
+      // if we match m_seekStream then we are ready
+      if (idx == m_seekStream)
+        return TRANSPORT_STREAM_STATE::READY;
       st = m_pFormatContext->streams[idx];
-      if (st->codecpar->codec_type == AVMEDIA_TYPE_AUDIO)
+      if (st->codecpar->codec_type == AVMEDIA_TYPE_AUDIO && idx == m_pkt.pkt.stream_index)
       {
-        if (st->start_time != AV_NOPTS_VALUE)
+        if (m_pkt.pkt.dts != AV_NOPTS_VALUE)
         {
           if (!m_startTime)
           {
@@ -1788,10 +1791,14 @@ TRANSPORT_STREAM_STATE FFmpegStream::TransportStreamAudioState()
   {
     for (unsigned int i = 0; i < m_pFormatContext->nb_streams; i++)
     {
+      // if we match m_seekStream then we are ready
+      if (static_cast<int>(i) == m_seekStream)
+        return TRANSPORT_STREAM_STATE::READY;
       st = m_pFormatContext->streams[i];
-      if (st->codecpar->codec_type == AVMEDIA_TYPE_AUDIO)
+      if (st->codecpar->codec_type == AVMEDIA_TYPE_AUDIO &&
+          static_cast<int>(i) == m_pkt.pkt.stream_index)
       {
-        if (st->start_time != AV_NOPTS_VALUE)
+        if (m_pkt.pkt.dts != AV_NOPTS_VALUE)
         {
           if (!m_startTime)
           {
@@ -1821,10 +1828,13 @@ TRANSPORT_STREAM_STATE FFmpegStream::TransportStreamVideoState()
     for (unsigned int i = 0; i < m_pFormatContext->programs[m_program]->nb_stream_indexes; i++)
     {
       int idx = m_pFormatContext->programs[m_program]->stream_index[i];
+      // if we match m_seekStream then we are ready
+      if (idx == m_seekStream)
+        return TRANSPORT_STREAM_STATE::READY;
       st = m_pFormatContext->streams[idx];
-      if (st->codecpar->codec_type == AVMEDIA_TYPE_VIDEO)
+      if (st->codecpar->codec_type == AVMEDIA_TYPE_VIDEO && idx == m_pkt.pkt.stream_index)
       {
-        if (st->codecpar->extradata)
+        if (m_pkt.pkt.dts != AV_NOPTS_VALUE && st->codecpar->extradata)
         {
           if (!m_startTime)
           {
@@ -1841,10 +1851,14 @@ TRANSPORT_STREAM_STATE FFmpegStream::TransportStreamVideoState()
   {
     for (unsigned int i = 0; i < m_pFormatContext->nb_streams; i++)
     {
+      // if we match m_seekStream then we are ready
+      if (static_cast<int>(i) == m_seekStream)
+        return TRANSPORT_STREAM_STATE::READY;
       st = m_pFormatContext->streams[i];
-      if (st->codecpar->codec_type == AVMEDIA_TYPE_VIDEO)
+      if (st->codecpar->codec_type == AVMEDIA_TYPE_VIDEO &&
+          static_cast<int>(i) == m_pkt.pkt.stream_index)
       {
-        if (st->codecpar->extradata)
+        if (m_pkt.pkt.dts != AV_NOPTS_VALUE && st->codecpar->extradata)
         {
           if (!m_startTime)
           {

--- a/src/stream/FFmpegStream.cpp
+++ b/src/stream/FFmpegStream.cpp
@@ -31,6 +31,7 @@
 extern "C" {
 #include <libavcodec/bsf.h>
 #include <libavutil/dict.h>
+#include <libavutil/dovi_meta.h>
 #include <libavutil/opt.h>
 #include "libavutil/pixdesc.h"
 }
@@ -2045,6 +2046,15 @@ DemuxStream* FFmpegStream::AddStream(int streamIdx)
         // https://github.com/FFmpeg/FFmpeg/blob/release/5.0/doc/APIchanges
         size_t size = 0;
         uint8_t* side_data = nullptr;
+
+        if (st->hdr_type == StreamHdrType::HDR_TYPE_DOLBYVISION)
+        {
+          side_data = av_stream_get_side_data(pStream, AV_PKT_DATA_DOVI_CONF, &size);
+          if (side_data && size)
+          {
+            st->dovi = *reinterpret_cast<AVDOVIDecoderConfigurationRecord*>(side_data);
+          }
+        }
 
         side_data = av_stream_get_side_data(pStream, AV_PKT_DATA_MASTERING_DISPLAY_METADATA, &size);
         if (side_data && size)

--- a/src/stream/FFmpegStream.cpp
+++ b/src/stream/FFmpegStream.cpp
@@ -1328,6 +1328,7 @@ std::vector<DemuxStream*> FFmpegStream::GetDemuxStreams() const
 {
   std::vector<DemuxStream*> streams;
 
+  streams.reserve(m_streams.size());
   for (auto& iter : m_streams)
     streams.push_back(iter.second);
 

--- a/src/stream/FFmpegStream.cpp
+++ b/src/stream/FFmpegStream.cpp
@@ -2012,6 +2012,29 @@ DemuxStream* FFmpegStream::AddStream(int streamIdx)
         st->iBitsPerPixel = pStream->codecpar->bits_per_coded_sample;
         st->iBitRate = static_cast<int>(pStream->codecpar->bit_rate);
 
+        st->colorPrimaries = pStream->codecpar->color_primaries;
+        st->colorSpace = pStream->codecpar->color_space;
+        st->colorTransferCharacteristic = pStream->codecpar->color_trc;
+        st->colorRange = pStream->codecpar->color_range;
+
+        // https://github.com/FFmpeg/FFmpeg/blob/release/5.0/doc/APIchanges
+        size_t size = 0;
+        uint8_t* side_data = nullptr;
+
+        side_data = av_stream_get_side_data(pStream, AV_PKT_DATA_MASTERING_DISPLAY_METADATA, &size);
+        if (side_data && size)
+        {
+          st->masteringMetaData = std::make_shared<AVMasteringDisplayMetadata>(
+              *reinterpret_cast<AVMasteringDisplayMetadata*>(side_data));
+        }
+
+        side_data = av_stream_get_side_data(pStream, AV_PKT_DATA_CONTENT_LIGHT_LEVEL, &size);
+        if (side_data && size)
+        {
+          st->contentLightMetaData = std::make_shared<AVContentLightMetadata>(
+              *reinterpret_cast<AVContentLightMetadata*>(side_data));
+        }
+
         AVDictionaryEntry* rtag = av_dict_get(pStream->metadata, "rotate", NULL, 0);
         if (rtag)
           st->iOrientation = atoi(rtag->value);

--- a/src/stream/FFmpegStream.cpp
+++ b/src/stream/FFmpegStream.cpp
@@ -1165,7 +1165,7 @@ double FFmpegStream::ConvertTimestamp(int64_t pts, int den, int num)
   //if ((!menuInterface || menuInterface->GetSupportedMenuType() != MenuType::NATIVE) &&
   if (m_pFormatContext->start_time != static_cast<int64_t>(AV_NOPTS_VALUE))
   {
-    starttime = static_cast<double>(m_pFormatContext->start_time / AV_TIME_BASE);
+    starttime = static_cast<double>(m_pFormatContext->start_time) / AV_TIME_BASE;
   }
 
   if (m_checkTransportStream)

--- a/src/stream/FFmpegStream.cpp
+++ b/src/stream/FFmpegStream.cpp
@@ -1545,6 +1545,24 @@ bool FFmpegStream::SeekTime(double time, bool backwards, double* startpts)
     }
   }
 
+  if (ret >= 0)
+  {
+    kodi::tools::CEndTime timer(1000);
+    while (m_currentPts == STREAM_NOPTS_VALUE && !timer.IsTimePast())
+    {
+      m_pkt.result = -1;
+      av_packet_unref(&m_pkt.pkt);
+
+      DEMUX_PACKET* pkt = DemuxRead();
+      if (!pkt)
+      {
+        std::this_thread::sleep_for(std::chrono::milliseconds(10));
+        continue;
+      }
+      m_demuxPacketManager->FreeDemuxPacketFromInputStreamAPI(pkt);
+    }
+  }
+
   if (m_currentPts == STREAM_NOPTS_VALUE)
     Log(LOGLEVEL_DEBUG, "%s - unknown position after seek", __FUNCTION__);
   else

--- a/src/stream/FFmpegStream.cpp
+++ b/src/stream/FFmpegStream.cpp
@@ -1956,7 +1956,7 @@ DemuxStream* FFmpegStream::AddStream(int streamIdx)
         st->iBlockAlign = pStream->codecpar->block_align;
         st->iBitRate = static_cast<int>(pStream->codecpar->bit_rate);
         st->iBitsPerSample = pStream->codecpar->bits_per_raw_sample;
-        char buf[32] = { 0 };
+        char buf[32] = {};
         // https://github.com/FFmpeg/FFmpeg/blob/6ccc3989d15/doc/APIchanges#L50-L53
         AVChannelLayout layout = {};
         av_channel_layout_from_mask(&layout, st->iChannelLayout);

--- a/src/stream/FFmpegStream.cpp
+++ b/src/stream/FFmpegStream.cpp
@@ -451,7 +451,7 @@ DEMUX_PACKET* FFmpegStream::DemuxRead()
     return nullptr;
 
   // check streams, can we make this a bit more simple?
-  if (pPacket && pPacket->iStreamId >= 0)
+  if (pPacket->iStreamId >= 0)
   {
     DemuxStream* stream = GetDemuxStream(pPacket->iStreamId);
     if (!stream ||

--- a/src/stream/FFmpegStream.cpp
+++ b/src/stream/FFmpegStream.cpp
@@ -2015,6 +2015,11 @@ DemuxStream* FFmpegStream::AddStream(int streamIdx)
           st->iFpsScale = 0;
         }
 
+        st->bInterlaced = pStream->codecpar->field_order == AV_FIELD_TT ||
+                         pStream->codecpar->field_order == AV_FIELD_BB ||
+                         pStream->codecpar->field_order == AV_FIELD_TB ||
+                         pStream->codecpar->field_order == AV_FIELD_BT;
+
         st->iWidth = pStream->codecpar->width;
         st->iHeight = pStream->codecpar->height;
         st->fAspect = SelectAspect(pStream, st->bForcedAspect);

--- a/src/stream/FFmpegStream.cpp
+++ b/src/stream/FFmpegStream.cpp
@@ -1153,7 +1153,7 @@ double FFmpegStream::ConvertTimestamp(int64_t pts, int den, int num)
   // do calculations in floats as they can easily overflow otherwise
   // we don't care for having a completely exact timestamp anyway
   double timestamp = (double)pts * num / den;
-  double starttime = 0.0f;
+  double starttime = 0.0;
 
   //std::shared_ptr<CDVDInputStream::IMenus> menu = std::dynamic_pointer_cast<CDVDInputStream::IMenus>(m_pInput);
   //if (!menu && m_pFormatContext->start_time != (int64_t)AV_NOPTS_VALUE)
@@ -1168,7 +1168,7 @@ double FFmpegStream::ConvertTimestamp(int64_t pts, int den, int num)
     if (timestamp > starttime || m_checkTransportStream)
       timestamp -= starttime;
     // allow for largest possible difference in pts and dts for a single packet
-    else if (timestamp + 0.5f > starttime)
+    else if (timestamp + 0.5 > starttime)
       timestamp = 0;
   }
 

--- a/src/stream/FFmpegStream.cpp
+++ b/src/stream/FFmpegStream.cpp
@@ -1768,9 +1768,6 @@ TRANSPORT_STREAM_STATE FFmpegStream::TransportStreamAudioState()
     for (unsigned int i = 0; i < m_pFormatContext->programs[m_program]->nb_stream_indexes; i++)
     {
       int idx = m_pFormatContext->programs[m_program]->stream_index[i];
-      // if we match m_seekStream then we are ready
-      if (idx == m_seekStream)
-        return TRANSPORT_STREAM_STATE::READY;
       st = m_pFormatContext->streams[idx];
       if (st->codecpar->codec_type == AVMEDIA_TYPE_AUDIO)
       {
@@ -1791,9 +1788,6 @@ TRANSPORT_STREAM_STATE FFmpegStream::TransportStreamAudioState()
   {
     for (unsigned int i = 0; i < m_pFormatContext->nb_streams; i++)
     {
-      // if we match m_seekStream then we are ready
-      if (static_cast<int>(i) == m_seekStream)
-        return TRANSPORT_STREAM_STATE::READY;
       st = m_pFormatContext->streams[i];
       if (st->codecpar->codec_type == AVMEDIA_TYPE_AUDIO)
       {
@@ -1810,6 +1804,8 @@ TRANSPORT_STREAM_STATE FFmpegStream::TransportStreamAudioState()
       }
     }
   }
+  if (hasAudio && m_startTime)
+    return TRANSPORT_STREAM_STATE::READY;
 
   return (hasAudio) ? TRANSPORT_STREAM_STATE::NOTREADY : TRANSPORT_STREAM_STATE::NONE;
 }
@@ -1827,9 +1823,6 @@ TRANSPORT_STREAM_STATE FFmpegStream::TransportStreamVideoState()
     for (unsigned int i = 0; i < m_pFormatContext->programs[m_program]->nb_stream_indexes; i++)
     {
       int idx = m_pFormatContext->programs[m_program]->stream_index[i];
-      // if we match m_seekStream then we are ready
-      if (idx == m_seekStream)
-        return TRANSPORT_STREAM_STATE::READY;
       st = m_pFormatContext->streams[idx];
       if (st->codecpar->codec_type == AVMEDIA_TYPE_VIDEO)
       {
@@ -1851,9 +1844,6 @@ TRANSPORT_STREAM_STATE FFmpegStream::TransportStreamVideoState()
   {
     for (unsigned int i = 0; i < m_pFormatContext->nb_streams; i++)
     {
-      // if we match m_seekStream then we are ready
-      if (static_cast<int>(i) == m_seekStream)
-        return TRANSPORT_STREAM_STATE::READY;
       st = m_pFormatContext->streams[i];
       if (st->codecpar->codec_type == AVMEDIA_TYPE_VIDEO)
       {
@@ -1871,6 +1861,8 @@ TRANSPORT_STREAM_STATE FFmpegStream::TransportStreamVideoState()
       }
     }
   }
+  if (hasVideo && m_startTime)
+    return TRANSPORT_STREAM_STATE::READY;
 
   return (hasVideo) ? TRANSPORT_STREAM_STATE::NOTREADY : TRANSPORT_STREAM_STATE::NONE;
 }

--- a/src/stream/FFmpegStream.cpp
+++ b/src/stream/FFmpegStream.cpp
@@ -32,6 +32,7 @@ extern "C" {
 #include <libavcodec/bsf.h>
 #include <libavutil/dict.h>
 #include <libavutil/opt.h>
+#include "libavutil/pixdesc.h"
 }
 
 #include <kodi/tools/StringUtils.h>
@@ -2015,6 +2016,11 @@ DemuxStream* FFmpegStream::AddStream(int streamIdx)
         st->iOrientation = 0;
         st->iBitsPerPixel = pStream->codecpar->bits_per_coded_sample;
         st->iBitRate = static_cast<int>(pStream->codecpar->bit_rate);
+        st->iBitDepth = 8;
+        const AVPixFmtDescriptor* desc =
+            av_pix_fmt_desc_get(static_cast<AVPixelFormat>(pStream->codecpar->format));
+        if (desc != nullptr && desc->comp != nullptr)
+          st->iBitDepth = desc->comp[0].depth;
 
         st->colorPrimaries = pStream->codecpar->color_primaries;
         st->colorSpace = pStream->codecpar->color_space;

--- a/src/stream/FFmpegStream.cpp
+++ b/src/stream/FFmpegStream.cpp
@@ -16,6 +16,7 @@
 
 #include <chrono>
 #include <ctime>
+#include <memory>
 #include <thread>
 
 #ifndef __STDC_CONSTANT_MACROS
@@ -1701,8 +1702,7 @@ void FFmpegStream::ParsePacket(AVPacket* pkt)
     auto parser = m_parsers.find(st->index);
     if (parser == m_parsers.end())
     {
-      m_parsers.insert(std::make_pair(st->index,
-                                      std::unique_ptr<DemuxParserFFmpeg>(new DemuxParserFFmpeg())));
+      m_parsers.insert(std::make_pair(st->index, std::make_unique<DemuxParserFFmpeg>()));
       parser = m_parsers.find(st->index);
 
       parser->second->m_parserCtx = av_parser_init(st->codecpar->codec_id);

--- a/src/stream/FFmpegStream.cpp
+++ b/src/stream/FFmpegStream.cpp
@@ -1160,8 +1160,9 @@ double FFmpegStream::ConvertTimestamp(int64_t pts, int den, int num)
   double timestamp = (double)pts * num / den;
   double starttime = 0.0;
 
-  //std::shared_ptr<CDVDInputStream::IMenus> menu = std::dynamic_pointer_cast<CDVDInputStream::IMenus>(m_pInput);
-  //if ((!menu || !menu->HasMenu()) &&
+  //const std::shared_ptr<CDVDInputStream::IMenus> menuInterface =
+  //    std::dynamic_pointer_cast<CDVDInputStream::IMenus>(m_pInput);
+  //if ((!menuInterface || menuInterface->GetSupportedMenuType() != MenuType::NATIVE) &&
   if (m_pFormatContext->start_time != static_cast<int64_t>(AV_NOPTS_VALUE))
   {
     starttime = static_cast<double>(m_pFormatContext->start_time / AV_TIME_BASE);

--- a/src/stream/FFmpegStream.cpp
+++ b/src/stream/FFmpegStream.cpp
@@ -2019,7 +2019,7 @@ DemuxStream* FFmpegStream::AddStream(int streamIdx)
         st->iBitDepth = 8;
         const AVPixFmtDescriptor* desc =
             av_pix_fmt_desc_get(static_cast<AVPixelFormat>(pStream->codecpar->format));
-        if (desc != nullptr && desc->comp != nullptr)
+        if (desc != nullptr)
           st->iBitDepth = desc->comp[0].depth;
 
         st->colorPrimaries = pStream->codecpar->color_primaries;

--- a/src/stream/FFmpegStream.cpp
+++ b/src/stream/FFmpegStream.cpp
@@ -1239,8 +1239,6 @@ bool FFmpegStream::IsProgramChange()
       return true;
     if (m_pFormatContext->streams[idx]->codecpar->codec_id != stream->codec)
       return true;
-      int codecparChannels =
-          m_pFormatContext->streams[idx]->codecpar->ch_layout.nb_channels;
     if (m_pFormatContext->streams[idx]->codecpar->codec_type == AVMEDIA_TYPE_AUDIO)
     {
       DemuxStreamAudio* audiostream = dynamic_cast<DemuxStreamAudio*>(stream);

--- a/src/stream/FFmpegStream.cpp
+++ b/src/stream/FFmpegStream.cpp
@@ -1161,9 +1161,11 @@ double FFmpegStream::ConvertTimestamp(int64_t pts, int den, int num)
   double starttime = 0.0;
 
   //std::shared_ptr<CDVDInputStream::IMenus> menu = std::dynamic_pointer_cast<CDVDInputStream::IMenus>(m_pInput);
-  //if (!menu && m_pFormatContext->start_time != (int64_t)AV_NOPTS_VALUE)
-  if (m_pFormatContext->start_time != (int64_t)AV_NOPTS_VALUE)
-    starttime = (double)m_pFormatContext->start_time / AV_TIME_BASE;
+  //if ((!menu || !menu->HasMenu()) &&
+  if (m_pFormatContext->start_time != static_cast<int64_t>(AV_NOPTS_VALUE))
+  {
+    starttime = static_cast<double>(m_pFormatContext->start_time / AV_TIME_BASE);
+  }
 
   if (m_checkTransportStream)
     starttime = m_startTime;

--- a/src/stream/FFmpegStream.cpp
+++ b/src/stream/FFmpegStream.cpp
@@ -2084,10 +2084,9 @@ DemuxStream* FFmpegStream::AddStream(int streamIdx)
             av_dict_get(pStream->metadata, "mimetype", nullptr, 0);
 
         if (pStream->codecpar->codec_id == AV_CODEC_ID_TTF ||
-            pStream->codecpar->codec_id == AV_CODEC_ID_OTF ||
-            AttachmentIsFont(attachmentMimetype))
+            pStream->codecpar->codec_id == AV_CODEC_ID_OTF || AttachmentIsFont(attachmentMimetype))
         {
-          std::string fileName = "special://temp/fonts/";
+          std::string fileName = "special://home/media/Fonts/";
           kodi::vfs::CreateDirectory(fileName);
           AVDictionaryEntry* nameTag = av_dict_get(pStream->metadata, "filename", NULL, 0);
           if (!nameTag)
@@ -2096,7 +2095,11 @@ DemuxStream* FFmpegStream::AddStream(int streamIdx)
           }
           else
           {
-            fileName += FilenameUtils::MakeLegalFileName(nameTag->value, LEGAL_WIN32_COMPAT);
+            // Note: libass only supports a single font directory to look for aditional fonts
+            // (c.f. ass_set_fonts_dir). To support both user defined fonts (those placed in
+            // special://home/media/Fonts/) and fonts extracted by the demuxer, make it extract
+            // fonts to the user directory with a known, easy to identify, prefix (tmp.font.*).
+            fileName += "tmp.font." + FilenameUtils::MakeLegalFileName(nameTag->value, LEGAL_WIN32_COMPAT);
             kodi::vfs::CFile file;
             if (pStream->codecpar->extradata && file.OpenFileForWrite(fileName))
             {

--- a/src/stream/FFmpegStream.cpp
+++ b/src/stream/FFmpegStream.cpp
@@ -2120,11 +2120,16 @@ DemuxStream* FFmpegStream::AddStream(int streamIdx)
           }
           else
           {
-            // Note: libass only supports a single font directory to look for additional fonts
-            // (c.f. ass_set_fonts_dir). To support both user defined fonts (those placed in
-            // special://home/media/Fonts/) and fonts extracted by the demuxer, make it extract
-            // fonts to the user directory with a known, easy to identify, prefix (tmp.font.*).
-            fileName += "tmp.font." + FilenameUtils::MakeLegalFileName(nameTag->value, LEGAL_WIN32_COMPAT);
+            // Note: Libass only supports a single additional font directory,
+            // currently set for user fonts (c.f. ass_set_fonts_dir) therefore
+            // we will also use this folder to store fonts extracted by the
+            // demuxer. The extracted fonts will have a prefix in the filename
+            // for easy identification.
+            //! @todo: this font file management system on disk could be completely
+            //! removed, by sending font data to the subtitle renderer and
+            //! using libass ass_add_font to add the fonts directly in memory.
+            fileName += FilenameUtils::TEMP_FONT_FILENAME_PREFIX +
+                        FilenameUtils::MakeLegalFileName(nameTag->value, LEGAL_WIN32_COMPAT);
             kodi::vfs::CFile file;
             if (pStream->codecpar->extradata && file.OpenFileForWrite(fileName))
             {

--- a/src/stream/FFmpegStream.cpp
+++ b/src/stream/FFmpegStream.cpp
@@ -1728,7 +1728,7 @@ void FFmpegStream::ParsePacket(AVPacket* pkt)
       if (retExtraData)
       {
         st->codecpar->extradata_size = retExtraData.GetSize();
-        st->codecpar->extradata = retExtraData.GetData();
+        st->codecpar->extradata = retExtraData.TakeData();
 
         if (parser->second->m_parserCtx->parser->parser_parse)
         {

--- a/src/stream/FFmpegStream.cpp
+++ b/src/stream/FFmpegStream.cpp
@@ -2026,31 +2026,17 @@ DemuxStream* FFmpegStream::AddStream(int streamIdx)
         st->colorSpace = pStream->codecpar->color_space;
         st->colorTransferCharacteristic = pStream->codecpar->color_trc;
         st->colorRange = pStream->codecpar->color_range;
+        st->hdr_type = DetermineHdrType(pStream);
 
         // https://github.com/FFmpeg/FFmpeg/blob/release/5.0/doc/APIchanges
         size_t size = 0;
         uint8_t* side_data = nullptr;
-
-        side_data = av_stream_get_side_data(pStream, AV_PKT_DATA_DOVI_CONF, &size);
-        if (side_data && size)
-          st->hdr_type = StreamHdrType::HDR_TYPE_DOLBYVISION;
-        else if (st->colorPrimaries == AVCOL_PRI_BT2020)
-        {
-          if (st->colorTransferCharacteristic == AVCOL_TRC_SMPTE2084) // hdr10
-            st->hdr_type = StreamHdrType::HDR_TYPE_HDR10;
-          else if (st->colorTransferCharacteristic == AVCOL_TRC_ARIB_STD_B67) // hlg
-            st->hdr_type = StreamHdrType::HDR_TYPE_HLG;
-        }
 
         side_data = av_stream_get_side_data(pStream, AV_PKT_DATA_MASTERING_DISPLAY_METADATA, &size);
         if (side_data && size)
         {
           st->masteringMetaData = std::make_shared<AVMasteringDisplayMetadata>(
               *reinterpret_cast<AVMasteringDisplayMetadata*>(side_data));
-          // file could be SMPTE2086 which FFmpeg currently returns as unknown so use the presence
-          // of static metadata to detect it
-          if (st->masteringMetaData->has_primaries && st->masteringMetaData->has_luminance)
-            st->hdr_type = StreamHdrType::HDR_TYPE_HDR10;
         }
 
         side_data = av_stream_get_side_data(pStream, AV_PKT_DATA_CONTENT_LIGHT_LEVEL, &size);
@@ -2215,6 +2201,24 @@ DemuxStream* FFmpegStream::AddStream(int streamIdx)
   }
   else
     return nullptr;
+}
+
+StreamHdrType FFmpegStream::DetermineHdrType(AVStream* pStream)
+{
+  StreamHdrType hdrType = StreamHdrType::HDR_TYPE_NONE;
+
+  if (av_stream_get_side_data(pStream, AV_PKT_DATA_DOVI_CONF, nullptr)) // DoVi
+    hdrType = StreamHdrType::HDR_TYPE_DOLBYVISION;
+  else if (pStream->codecpar->color_trc == AVCOL_TRC_SMPTE2084) // HDR10
+    hdrType = StreamHdrType::HDR_TYPE_HDR10;
+  else if (pStream->codecpar->color_trc == AVCOL_TRC_ARIB_STD_B67) // HLG
+    hdrType = StreamHdrType::HDR_TYPE_HLG;
+  // file could be SMPTE2086 which FFmpeg currently returns as unknown
+  // so use the presence of static metadata to detect it
+  else if (av_stream_get_side_data(pStream, AV_PKT_DATA_MASTERING_DISPLAY_METADATA, nullptr))
+    hdrType = StreamHdrType::HDR_TYPE_HDR10;
+
+  return hdrType;
 }
 
 /**

--- a/src/stream/FFmpegStream.cpp
+++ b/src/stream/FFmpegStream.cpp
@@ -438,6 +438,11 @@ DEMUX_PACKET* FFmpegStream::DemuxRead()
           m_currentPts = pPacket->dts;
           CurrentPTSUpdated();
         }
+        else if (pPacket->pts != STREAM_NOPTS_VALUE && (pPacket->pts > m_currentPts || m_currentPts == STREAM_NOPTS_VALUE))
+        {
+          m_currentPts = pPacket->pts;
+          CurrentPTSUpdated();
+        }
 
         // store internal id until we know the continuous id presented to player
         // the stream might not have been created yet

--- a/src/stream/FFmpegStream.h
+++ b/src/stream/FFmpegStream.h
@@ -108,7 +108,7 @@ protected:
   bool IsPaused() { return m_speed == STREAM_PLAYSPEED_PAUSE; }
   virtual bool CheckReturnEmptyOnPacketResult(int result);
 
-  int GetPacketExtradata(const AVPacket* pkt, const AVCodecParserContext* parserCtx, AVCodecContext* codecCtx, uint8_t **p_extradata);
+  FFmpegExtraData GetPacketExtradata(const AVPacket* pkt, const AVCodecParameters* codecPar);
 
   int64_t m_demuxerId;
   mutable std::recursive_mutex m_mutex;

--- a/src/stream/FFmpegStream.h
+++ b/src/stream/FFmpegStream.h
@@ -104,7 +104,7 @@ public:
 
 protected:
   virtual std::string GetStreamCodecName(int iStreamId);
-  virtual void UpdateCurrentPTS();
+  virtual void CurrentPTSUpdated();
   bool IsPaused() { return m_speed == STREAM_PLAYSPEED_PAUSE; }
   virtual bool CheckReturnEmptyOnPacketResult(int result);
 

--- a/src/stream/FFmpegStream.h
+++ b/src/stream/FFmpegStream.h
@@ -136,6 +136,7 @@ private:
   DemuxStream* AddStream(int streamIdx);
   void GetL16Parameters(int& channels, int& samplerate);
   double SelectAspect(AVStream* st, bool& forced);
+  StreamHdrType DetermineHdrType(AVStream* pStream);
   std::string GetStereoModeFromMetadata(AVDictionary* pMetadata);
   std::string ConvertCodecToInternalStereoMode(const std::string &mode, const StereoModeConversionMap* conversionMap);
   bool SeekTime(double time, bool backwards = false, double* startpts = nullptr);

--- a/src/utils/FilenameUtils.cpp
+++ b/src/utils/FilenameUtils.cpp
@@ -9,8 +9,28 @@
 
 #include <kodi/tools/StringUtils.h>
 
+#include <regex>
+
 using namespace ffmpegdirect;
 using namespace kodi::tools;
+
+std::string FilenameUtils::FindLanguageCodeWithSubtag(const std::string& str)
+{
+  static std::regex regLangCode("(?:^|\\s|\\()(([A-Za-z]{2,3})-([A-Za-z]{2}|[0-9]{3}|[A-Za-z]{4}))(?:$|\\s|\\))");
+  std::smatch match;
+  std::string matchText = "";
+
+  if (std::regex_match(str, match, regLangCode))
+  {
+    if (match.size() == 2)
+    {
+      std::ssub_match base_sub_match = match[1];
+      matchText = base_sub_match.str();
+    }
+  }
+
+  return matchText;
+}
 
 std::string FilenameUtils::MakeLegalFileName(const std::string &strFile, int LegalType)
 {

--- a/src/utils/FilenameUtils.h
+++ b/src/utils/FilenameUtils.h
@@ -15,8 +15,7 @@ namespace ffmpegdirect
   static const int LEGAL_WIN32_COMPAT = 1;
   static const int LEGAL_FATX = 2;
 
-  // Prefix used to store temporary font files in the user fonts folder
-  constexpr const char* TEMP_FONT_FILENAME_PREFIX = "tmp.font.";
+  constexpr const char* TEMP_FONT_PATH = "special://temp/fonts/";
 
   class FilenameUtils
   {

--- a/src/utils/FilenameUtils.h
+++ b/src/utils/FilenameUtils.h
@@ -15,6 +15,9 @@ namespace ffmpegdirect
   static const int LEGAL_WIN32_COMPAT = 1;
   static const int LEGAL_FATX = 2;
 
+  // Prefix used to store temporary font files in the user fonts folder
+  constexpr const char* TEMP_FONT_FILENAME_PREFIX = "tmp.font.";
+
   class FilenameUtils
   {
   public:
@@ -24,6 +27,6 @@ namespace ffmpegdirect
 #else
     static std::string MakeLegalFileName(const std::string &strFile, int LegalType=LEGAL_NONE);
     static std::string MakeLegalPath(const std::string &strPath, int LegalType=LEGAL_NONE);
-#endif      
+#endif
   };
 } //namespace ffmpegdirect

--- a/src/utils/FilenameUtils.h
+++ b/src/utils/FilenameUtils.h
@@ -20,6 +20,17 @@ namespace ffmpegdirect
   class FilenameUtils
   {
   public:
+
+  /*
+   * \brief Find a language code with subtag (e.g. zh-tw, zh-Hans) in to a string.
+   *        This function find a limited set of IETF BCP47 specs, so:
+   *        language tag + region subtag, or, language tag + script subtag.
+   *        The language code can be found also if wrapped with round brackets.
+   * \param str The string where find the language code.
+   * \return The language code found in the string, otherwise empty string
+   */
+  static std::string FindLanguageCodeWithSubtag(const std::string& str);
+
 #ifdef TARGET_WINDOWS
     static std::string MakeLegalFileName(const std::string &strFile, int LegalType=LEGAL_WIN32_COMPAT);
     static std::string MakeLegalPath(const std::string &strPath, int LegalType=LEGAL_WIN32_COMPAT);


### PR DESCRIPTION
Part 1:

Syncronised all changes from https://github.com/xbmc/xbmc/commits/master/xbmc/cores/FFmpeg.cpp, and https://github.com/xbmc/xbmc/commits/master/xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemuxFFmpeg.cpp

Part 2:

Based off changes in Kodi PR: https://github.com/xbmc/xbmc/pull/23557/commits and https://github.com/xbmc/xbmc/pull/23629/commits

We remove calls to `UpdateCurrentPTS()` which is used for catchup support. So we need to adapt the [original](https://github.com/xbmc/xbmc/pull/23557/commits/55e661af2599b8856fbb3a2cf747e4ad0e531c1f) commit for our use case.

Instead for catchup we should call it in the correct place in order to seek correctly. In the base class it does nothing, but when we inherit it does.