### PR TITLE
Sync ffmpeg6 seek with kodi part2 - include the st->cur_pts replacement in FFmpeg6

### DIFF
--- a/inputstream.ffmpegdirect/addon.xml.in
+++ b/inputstream.ffmpegdirect/addon.xml.in
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <addon
   id="inputstream.ffmpegdirect"
-  version="21.3.0"
+  version="21.3.1"
   name="Inputstream FFmpeg Direct"
   provider-name="Ross Nicholson">
   <requires>@ADDON_DEPENDS@</requires>

--- a/inputstream.ffmpegdirect/changelog.txt
+++ b/inputstream.ffmpegdirect/changelog.txt
@@ -1,3 +1,7 @@
+v21.3.1
+- Update seeking in FFmpegDirect to mimic the st->cur_pts replacement in FFmpeg6
+- Sync FFmpegStream.cpp and DemuxStream.cpp with xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemuxFFmpeg.cpp from https://github.com/xbmc/xbmc. Update for all commits up to the end of 2023 - part 2
+
 v21.3.0
 - Sync FFmpegStream.cpp and DemuxStream.cpp with xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemuxFFmpeg.cpp from https://github.com/xbmc/xbmc. Update for all commits up to the end of 2023 part 1
 

--- a/src/stream/FFmpegCatchupStream.cpp
+++ b/src/stream/FFmpegCatchupStream.cpp
@@ -362,9 +362,9 @@ bool FFmpegCatchupStream::GetTimes(kodi::addon::InputstreamTimes& times)
   return true;
 }
 
-void FFmpegCatchupStream::UpdateCurrentPTS()
+void FFmpegCatchupStream::CurrentPTSUpdated()
 {
-  FFmpegStream::UpdateCurrentPTS();
+  FFmpegStream::CurrentPTSUpdated();
   if (m_currentPts != STREAM_NOPTS_VALUE)
     m_currentPts += m_seekOffset;
 }

--- a/src/stream/FFmpegCatchupStream.h
+++ b/src/stream/FFmpegCatchupStream.h
@@ -43,7 +43,7 @@ public:
   virtual bool IsRealTimeStream() override;
 
 protected:
-  void UpdateCurrentPTS() override;
+  void CurrentPTSUpdated() override;
   bool CheckReturnEmptyOnPacketResult(int result) override;
 
   long long GetCurrentLiveOffset() { return std::time(nullptr) - m_catchupBufferStartTime; }

--- a/src/stream/FFmpegStream.cpp
+++ b/src/stream/FFmpegStream.cpp
@@ -1772,9 +1772,9 @@ TRANSPORT_STREAM_STATE FFmpegStream::TransportStreamAudioState()
       if (idx == m_seekStream)
         return TRANSPORT_STREAM_STATE::READY;
       st = m_pFormatContext->streams[idx];
-      if (st->codecpar->codec_type == AVMEDIA_TYPE_AUDIO && idx == m_pkt.pkt.stream_index)
+      if (st->codecpar->codec_type == AVMEDIA_TYPE_AUDIO)
       {
-        if (m_pkt.pkt.dts != AV_NOPTS_VALUE)
+        if (idx == m_pkt.pkt.stream_index && m_pkt.pkt.dts != AV_NOPTS_VALUE)
         {
           if (!m_startTime)
           {
@@ -1795,10 +1795,9 @@ TRANSPORT_STREAM_STATE FFmpegStream::TransportStreamAudioState()
       if (static_cast<int>(i) == m_seekStream)
         return TRANSPORT_STREAM_STATE::READY;
       st = m_pFormatContext->streams[i];
-      if (st->codecpar->codec_type == AVMEDIA_TYPE_AUDIO &&
-          static_cast<int>(i) == m_pkt.pkt.stream_index)
+      if (st->codecpar->codec_type == AVMEDIA_TYPE_AUDIO)
       {
-        if (m_pkt.pkt.dts != AV_NOPTS_VALUE)
+        if (static_cast<int>(i) == m_pkt.pkt.stream_index && m_pkt.pkt.dts != AV_NOPTS_VALUE)
         {
           if (!m_startTime)
           {
@@ -1832,9 +1831,10 @@ TRANSPORT_STREAM_STATE FFmpegStream::TransportStreamVideoState()
       if (idx == m_seekStream)
         return TRANSPORT_STREAM_STATE::READY;
       st = m_pFormatContext->streams[idx];
-      if (st->codecpar->codec_type == AVMEDIA_TYPE_VIDEO && idx == m_pkt.pkt.stream_index)
+      if (st->codecpar->codec_type == AVMEDIA_TYPE_VIDEO)
       {
-        if (m_pkt.pkt.dts != AV_NOPTS_VALUE && st->codecpar->extradata)
+        if (idx == m_pkt.pkt.stream_index && m_pkt.pkt.dts != AV_NOPTS_VALUE &&
+            st->codecpar->extradata)
         {
           if (!m_startTime)
           {
@@ -1855,10 +1855,10 @@ TRANSPORT_STREAM_STATE FFmpegStream::TransportStreamVideoState()
       if (static_cast<int>(i) == m_seekStream)
         return TRANSPORT_STREAM_STATE::READY;
       st = m_pFormatContext->streams[i];
-      if (st->codecpar->codec_type == AVMEDIA_TYPE_VIDEO &&
-          static_cast<int>(i) == m_pkt.pkt.stream_index)
+      if (st->codecpar->codec_type == AVMEDIA_TYPE_VIDEO)
       {
-        if (m_pkt.pkt.dts != AV_NOPTS_VALUE && st->codecpar->extradata)
+        if (static_cast<int>(i) == m_pkt.pkt.stream_index && m_pkt.pkt.dts != AV_NOPTS_VALUE &&
+            st->codecpar->extradata)
         {
           if (!m_startTime)
           {

--- a/src/stream/FFmpegStream.cpp
+++ b/src/stream/FFmpegStream.cpp
@@ -1768,10 +1768,13 @@ TRANSPORT_STREAM_STATE FFmpegStream::TransportStreamAudioState()
     for (unsigned int i = 0; i < m_pFormatContext->programs[m_program]->nb_stream_indexes; i++)
     {
       int idx = m_pFormatContext->programs[m_program]->stream_index[i];
+      // if we match m_seekStream then we are ready
+      if (idx == m_seekStream)
+        return TRANSPORT_STREAM_STATE::READY;
       st = m_pFormatContext->streams[idx];
-      if (st->codecpar->codec_type == AVMEDIA_TYPE_AUDIO)
+      if (st->codecpar->codec_type == AVMEDIA_TYPE_AUDIO && idx == m_pkt.pkt.stream_index)
       {
-        if (st->start_time != AV_NOPTS_VALUE)
+        if (m_pkt.pkt.dts != AV_NOPTS_VALUE)
         {
           if (!m_startTime)
           {
@@ -1788,10 +1791,14 @@ TRANSPORT_STREAM_STATE FFmpegStream::TransportStreamAudioState()
   {
     for (unsigned int i = 0; i < m_pFormatContext->nb_streams; i++)
     {
+      // if we match m_seekStream then we are ready
+      if (static_cast<int>(i) == m_seekStream)
+        return TRANSPORT_STREAM_STATE::READY;
       st = m_pFormatContext->streams[i];
-      if (st->codecpar->codec_type == AVMEDIA_TYPE_AUDIO)
+      if (st->codecpar->codec_type == AVMEDIA_TYPE_AUDIO &&
+          static_cast<int>(i) == m_pkt.pkt.stream_index)
       {
-        if (st->start_time != AV_NOPTS_VALUE)
+        if (m_pkt.pkt.dts != AV_NOPTS_VALUE)
         {
           if (!m_startTime)
           {
@@ -1821,10 +1828,13 @@ TRANSPORT_STREAM_STATE FFmpegStream::TransportStreamVideoState()
     for (unsigned int i = 0; i < m_pFormatContext->programs[m_program]->nb_stream_indexes; i++)
     {
       int idx = m_pFormatContext->programs[m_program]->stream_index[i];
+      // if we match m_seekStream then we are ready
+      if (idx == m_seekStream)
+        return TRANSPORT_STREAM_STATE::READY;
       st = m_pFormatContext->streams[idx];
-      if (st->codecpar->codec_type == AVMEDIA_TYPE_VIDEO)
+      if (st->codecpar->codec_type == AVMEDIA_TYPE_VIDEO && idx == m_pkt.pkt.stream_index)
       {
-        if (st->codecpar->extradata)
+        if (m_pkt.pkt.dts != AV_NOPTS_VALUE && st->codecpar->extradata)
         {
           if (!m_startTime)
           {
@@ -1841,10 +1851,14 @@ TRANSPORT_STREAM_STATE FFmpegStream::TransportStreamVideoState()
   {
     for (unsigned int i = 0; i < m_pFormatContext->nb_streams; i++)
     {
+      // if we match m_seekStream then we are ready
+      if (static_cast<int>(i) == m_seekStream)
+        return TRANSPORT_STREAM_STATE::READY;
       st = m_pFormatContext->streams[i];
-      if (st->codecpar->codec_type == AVMEDIA_TYPE_VIDEO)
+      if (st->codecpar->codec_type == AVMEDIA_TYPE_VIDEO &&
+          static_cast<int>(i) == m_pkt.pkt.stream_index)
       {
-        if (st->codecpar->extradata)
+        if (m_pkt.pkt.dts != AV_NOPTS_VALUE && st->codecpar->extradata)
         {
           if (!m_startTime)
           {

--- a/src/stream/FFmpegStream.cpp
+++ b/src/stream/FFmpegStream.cpp
@@ -1545,6 +1545,24 @@ bool FFmpegStream::SeekTime(double time, bool backwards, double* startpts)
     }
   }
 
+  if (ret >= 0)
+  {
+    kodi::tools::CEndTime timer(1000);
+    while (m_currentPts == STREAM_NOPTS_VALUE && !timer.IsTimePast())
+    {
+      m_pkt.result = -1;
+      av_packet_unref(&m_pkt.pkt);
+
+      DEMUX_PACKET* pkt = DemuxRead();
+      if (!pkt)
+      {
+        std::this_thread::sleep_for(std::chrono::milliseconds(10));
+        continue;
+      }
+      m_demuxPacketManager->FreeDemuxPacketFromInputStreamAPI(pkt);
+    }
+  }
+
   if (m_currentPts == STREAM_NOPTS_VALUE)
     Log(LOGLEVEL_DEBUG, "%s - unknown position after seek", __FUNCTION__);
   else

--- a/src/stream/FFmpegStream.cpp
+++ b/src/stream/FFmpegStream.cpp
@@ -1768,9 +1768,6 @@ TRANSPORT_STREAM_STATE FFmpegStream::TransportStreamAudioState()
     for (unsigned int i = 0; i < m_pFormatContext->programs[m_program]->nb_stream_indexes; i++)
     {
       int idx = m_pFormatContext->programs[m_program]->stream_index[i];
-      // if we match m_seekStream then we are ready
-      if (idx == m_seekStream)
-        return TRANSPORT_STREAM_STATE::READY;
       st = m_pFormatContext->streams[idx];
       if (st->codecpar->codec_type == AVMEDIA_TYPE_AUDIO)
       {
@@ -1791,9 +1788,6 @@ TRANSPORT_STREAM_STATE FFmpegStream::TransportStreamAudioState()
   {
     for (unsigned int i = 0; i < m_pFormatContext->nb_streams; i++)
     {
-      // if we match m_seekStream then we are ready
-      if (static_cast<int>(i) == m_seekStream)
-        return TRANSPORT_STREAM_STATE::READY;
       st = m_pFormatContext->streams[i];
       if (st->codecpar->codec_type == AVMEDIA_TYPE_AUDIO)
       {
@@ -1810,6 +1804,8 @@ TRANSPORT_STREAM_STATE FFmpegStream::TransportStreamAudioState()
       }
     }
   }
+  if (hasAudio && m_startTime)
+    return TRANSPORT_STREAM_STATE::READY;
 
   return (hasAudio) ? TRANSPORT_STREAM_STATE::NOTREADY : TRANSPORT_STREAM_STATE::NONE;
 }
@@ -1827,9 +1823,6 @@ TRANSPORT_STREAM_STATE FFmpegStream::TransportStreamVideoState()
     for (unsigned int i = 0; i < m_pFormatContext->programs[m_program]->nb_stream_indexes; i++)
     {
       int idx = m_pFormatContext->programs[m_program]->stream_index[i];
-      // if we match m_seekStream then we are ready
-      if (idx == m_seekStream)
-        return TRANSPORT_STREAM_STATE::READY;
       st = m_pFormatContext->streams[idx];
       if (st->codecpar->codec_type == AVMEDIA_TYPE_VIDEO)
       {
@@ -1851,9 +1844,6 @@ TRANSPORT_STREAM_STATE FFmpegStream::TransportStreamVideoState()
   {
     for (unsigned int i = 0; i < m_pFormatContext->nb_streams; i++)
     {
-      // if we match m_seekStream then we are ready
-      if (static_cast<int>(i) == m_seekStream)
-        return TRANSPORT_STREAM_STATE::READY;
       st = m_pFormatContext->streams[i];
       if (st->codecpar->codec_type == AVMEDIA_TYPE_VIDEO)
       {
@@ -1871,6 +1861,8 @@ TRANSPORT_STREAM_STATE FFmpegStream::TransportStreamVideoState()
       }
     }
   }
+  if (hasVideo && m_startTime)
+    return TRANSPORT_STREAM_STATE::READY;
 
   return (hasVideo) ? TRANSPORT_STREAM_STATE::NOTREADY : TRANSPORT_STREAM_STATE::NONE;
 }

--- a/src/stream/FFmpegStream.cpp
+++ b/src/stream/FFmpegStream.cpp
@@ -438,6 +438,11 @@ DEMUX_PACKET* FFmpegStream::DemuxRead()
           m_currentPts = pPacket->dts;
           CurrentPTSUpdated();
         }
+        else if (pPacket->pts != STREAM_NOPTS_VALUE && (pPacket->pts > m_currentPts || m_currentPts == STREAM_NOPTS_VALUE))
+        {
+          m_currentPts = pPacket->pts;
+          CurrentPTSUpdated();
+        }
 
         // store internal id until we know the continuous id presented to player
         // the stream might not have been created yet

--- a/src/stream/FFmpegStream.h
+++ b/src/stream/FFmpegStream.h
@@ -104,7 +104,7 @@ public:
 
 protected:
   virtual std::string GetStreamCodecName(int iStreamId);
-  virtual void UpdateCurrentPTS();
+  virtual void CurrentPTSUpdated();
   bool IsPaused() { return m_speed == STREAM_PLAYSPEED_PAUSE; }
   virtual bool CheckReturnEmptyOnPacketResult(int result);
 


### PR DESCRIPTION
v21.3.1
- Update seeking in FFmpegDirect to mimic the st->cur_pts replacement in FFmpeg6
- Sync FFmpegStream.cpp and DemuxStream.cpp with xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemuxFFmpeg.cpp from https://github.com/xbmc/xbmc. Update for all commits up to the end of 2023 - part 2