### PR TITLE
Fix deprecations

### DIFF
--- a/inputstream.ffmpegdirect/addon.xml.in
+++ b/inputstream.ffmpegdirect/addon.xml.in
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <addon
   id="inputstream.ffmpegdirect"
-  version="21.3.1"
+  version="21.3.2"
   name="Inputstream FFmpeg Direct"
   provider-name="Ross Nicholson">
   <requires>@ADDON_DEPENDS@</requires>

--- a/inputstream.ffmpegdirect/changelog.txt
+++ b/inputstream.ffmpegdirect/changelog.txt
@@ -1,3 +1,6 @@
+v21.3.2
+- Fix deprecations for m_pFormatContext's codecpar->channels for streams ffmpeg6 and a single use of vsprintf
+
 v21.3.1
 - Update seeking in FFmpegDirect to mimic the st->cur_pts replacement in FFmpeg6
 - Sync FFmpegStream.cpp and DemuxStream.cpp with xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemuxFFmpeg.cpp from https://github.com/xbmc/xbmc. Update for all commits up to the end of 2023 - part 2

--- a/src/StreamManager.cpp
+++ b/src/StreamManager.cpp
@@ -47,7 +47,7 @@ void Log(const LogLevel logLevel, const char* format, ...)
   char buffer[16384];
   va_list args;
   va_start(args, format);
-  vsprintf(buffer, format, args);
+  vsnprintf(buffer, sizeof(buffer), format, args);
   va_end(args);
   kodi::Log(addonLevel, buffer);
 }

--- a/src/stream/FFmpegStream.cpp
+++ b/src/stream/FFmpegStream.cpp
@@ -474,8 +474,11 @@ DEMUX_PACKET* FFmpegStream::DemuxRead()
     else if (stream->type == INPUTSTREAM_TYPE_AUDIO)
     {
       DemuxStreamAudio* audiostream = dynamic_cast<DemuxStreamAudio*>(stream);
-      if (audiostream && (audiostream->iChannels != m_pFormatContext->streams[pPacket->iStreamId]->codecpar->channels ||
-          audiostream->iSampleRate != m_pFormatContext->streams[pPacket->iStreamId]->codecpar->sample_rate))
+      int codecparChannels =
+          m_pFormatContext->streams[pPacket->iStreamId]->codecpar->ch_layout.nb_channels;
+      if (audiostream && (audiostream->iChannels != codecparChannels ||
+                          audiostream->iSampleRate !=
+                              m_pFormatContext->streams[pPacket->iStreamId]->codecpar->sample_rate))
       {
         // content has changed
         stream = AddStream(pPacket->iStreamId);
@@ -1236,8 +1239,8 @@ bool FFmpegStream::IsProgramChange()
     if (m_pFormatContext->streams[idx]->codecpar->codec_type == AVMEDIA_TYPE_AUDIO)
     {
       DemuxStreamAudio* audiostream = dynamic_cast<DemuxStreamAudio*>(stream);
-      if (audiostream &&
-          m_pFormatContext->streams[idx]->codecpar->channels != audiostream->iChannels)
+      int codecparChannels = m_pFormatContext->streams[idx]->codecpar->ch_layout.nb_channels;
+      if (audiostream && codecparChannels != audiostream->iChannels)
       {
         return true;
       }


### PR DESCRIPTION
v21.3.2
- Fix deprecations for m_pFormatContext's codecpar->channels for streams ffmpeg6 and a single use of vsprintf