### PR TITLE
Patch to disable hardware acceleration for interlaced video on TvOS

### DIFF
--- a/depends/common/ffmpeg/0004-ffmpeg-tvos-disable-hw-accel-interlaced-video.patch
+++ b/depends/common/ffmpeg/0004-ffmpeg-tvos-disable-hw-accel-interlaced-video.patch
@@ -1,0 +1,34 @@
+diff -ur a/libavcodec/videotoolbox.c b/libavcodec/videotoolbox.c
+--- a/libavcodec/videotoolbox.c
++++ b/libavcodec/videotoolbox.c
+@@ -825,11 +825,18 @@
+         if (data)
+             CFDictionarySetValue(avc_info, CFSTR("esds"), data);
+         break;
+-    case kCMVideoCodecType_H264 :
++    case kCMVideoCodecType_H264 : {
++        H264Context *h = avctx->priv_data;
++        if (TARGET_OS_IPHONE && h->ps.sps->frame_mbs_only_flag == 0) {
++            av_log(avctx, AV_LOG_ERROR, "VideoToolbox cannot decode interlaced fields on iOS\n");
++            CFRelease(avc_info);
++            goto fail;
++        }
+         data = ff_videotoolbox_avcc_extradata_create(avctx);
+         if (data)
+             CFDictionarySetValue(avc_info, CFSTR("avcC"), data);
+         break;
++    }
+     case kCMVideoCodecType_HEVC :
+         data = ff_videotoolbox_hvcc_extradata_create(avctx);
+         if (data)
+@@ -855,6 +862,10 @@
+
+     CFRelease(avc_info);
+     return config_info;
++
++fail:
++    CFRelease(config_info);
++    return NULL;
+ }
+
+ static int videotoolbox_start(AVCodecContext *avctx)

--- a/inputstream.ffmpegdirect/addon.xml.in
+++ b/inputstream.ffmpegdirect/addon.xml.in
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <addon
   id="inputstream.ffmpegdirect"
-  version="21.3.2"
+  version="21.3.3"
   name="Inputstream FFmpeg Direct"
   provider-name="Ross Nicholson">
   <requires>@ADDON_DEPENDS@</requires>

--- a/inputstream.ffmpegdirect/changelog.txt
+++ b/inputstream.ffmpegdirect/changelog.txt
@@ -1,3 +1,7 @@
+v21.3.3
+- Patch to disable hardware acceleration for interlaced video on TvOS
+- Patch to check for nullptr on surface for dxva2 on window
+
 v21.3.2
 - Fix deprecations for m_pFormatContext's codecpar->channels for streams ffmpeg6 and a single use of vsprintf
 


### PR DESCRIPTION
v21.3.3
- Patch to disable hardware acceleration for interlaced video on TvOS