### PR TITLE
Patch dxva2 windows

### DIFF
--- a/depends/common/ffmpeg/0005-ffmpeg-windows-dxva2-check-nullptr-surface.patch
+++ b/depends/common/ffmpeg/0005-ffmpeg-windows-dxva2-check-nullptr-surface.patch
@@ -1,0 +1,12 @@
+diff --git a/libavcodec/dxva2.c b/libavcodec/dxva2.c
+--- a/libavcodec/dxva2.c
++++ b/libavcodec/dxva2.c
+@@ -777,7 +777,7 @@ unsigned ff_dxva2_get_surface_index(const AVCodecContext *avctx,
+ #if CONFIG_D3D11VA
+     if (avctx->pix_fmt == AV_PIX_FMT_D3D11)
+         return (intptr_t)frame->data[1];
+-    if (avctx->pix_fmt == AV_PIX_FMT_D3D11VA_VLD) {
++    if (avctx->pix_fmt == AV_PIX_FMT_D3D11VA_VLD && surface) {
+         D3D11_VIDEO_DECODER_OUTPUT_VIEW_DESC viewDesc;
+         ID3D11VideoDecoderOutputView_GetDesc((ID3D11VideoDecoderOutputView*) surface, &viewDesc);
+         return viewDesc.Texture2D.ArraySlice;

--- a/inputstream.ffmpegdirect/addon.xml.in
+++ b/inputstream.ffmpegdirect/addon.xml.in
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <addon
   id="inputstream.ffmpegdirect"
-  version="21.3.2"
+  version="21.3.3"
   name="Inputstream FFmpeg Direct"
   provider-name="Ross Nicholson">
   <requires>@ADDON_DEPENDS@</requires>

--- a/inputstream.ffmpegdirect/changelog.txt
+++ b/inputstream.ffmpegdirect/changelog.txt
@@ -1,3 +1,6 @@
+v21.3.3
+- Patch to check for nullptr on surface for dxva2 on window
+
 v21.3.2
 - Fix deprecations for m_pFormatContext's codecpar->channels for streams ffmpeg6 and a single use of vsprintf
 


### PR DESCRIPTION
v21.3.3

- Patch to check for nullptr on surface for dxva2 on window