### PR TITLE
Fix timeshift ffmpeg sizet

### DIFF
--- a/inputstream.ffmpegdirect/addon.xml.in
+++ b/inputstream.ffmpegdirect/addon.xml.in
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <addon
   id="inputstream.ffmpegdirect"
-  version="21.3.3"
+  version="21.3.4"
   name="Inputstream FFmpeg Direct"
   provider-name="Ross Nicholson">
   <requires>@ADDON_DEPENDS@</requires>

--- a/inputstream.ffmpegdirect/changelog.txt
+++ b/inputstream.ffmpegdirect/changelog.txt
@@ -1,3 +1,6 @@
+v21.3.4
+- Fix timeshift mode
+
 v21.3.3
 - Patch to check for nullptr on surface for dxva2 on window
 

--- a/src/stream/TimeshiftSegment.cpp
+++ b/src/stream/TimeshiftSegment.cpp
@@ -320,7 +320,7 @@ int TimeshiftSegment::LoadPacket(std::shared_ptr<DEMUX_PACKET>& packet)
     if (avPacket)
     {
       enum AVPacketSideDataType type;
-      int size;
+      size_t size;
       for (int i = 0; i < packet->iSideDataElems; i++)
       {
         m_fileHandle.Read(&type, sizeof(type));


### PR DESCRIPTION
v21.3.4
- Fix timeshift mode

ffmpeg5 moved to using size_t instead of int, as we read demux packet side data for timeshift we must also change it there

Fixes https://github.com/xbmc/inputstream.ffmpegdirect/issues/282