### PR TITLE
Update StreamManager.h

### DIFF
--- a/src/StreamManager.h
+++ b/src/StreamManager.h
@@ -57,7 +57,7 @@ public:
   virtual DEMUX_PACKET* DemuxRead() override;
   virtual bool DemuxSeekTime(double time, bool backwards, double& startpts) override;
   virtual void DemuxSetSpeed(int speed) override;
-  virtual void SetVideoResolution(unsigned int width, unsigned int height) override;
+  virtual void SetVideoResolution(unsigned int width, unsigned int height);
 
   virtual int GetTotalTime() override;
   virtual int GetTime() override;


### PR DESCRIPTION
During compilation of inputstream.ffmpegdirect-20.3.0-Nexus on Slackware aarch64 I got the error:

/home/john/Downloads/addons/inputstream.ffmpegdirect/src/StreamManager.h:60:16: error: �..virtual void InputStreamFFmpegDirect::SetVideoResolution(int, int)�.. marked �..override�.., but does not override 60 | virtual void SetVideoResolution(int width, int height) override;

=> Solved by removing "override" from line 60 in StreamManager.h