### PR TITLE
[depends] Bring back libdl patch to fix webOS build failure

### DIFF
--- a/depends/common/gnutls/03-include-libdl-if-available.patch
+++ b/depends/common/gnutls/03-include-libdl-if-available.patch
@@ -1,0 +1,24 @@
+diff -ur gnutls/configure.ac gnutls-patched/configure.ac
+--- gnutls/configure.ac	2020-09-04 07:37:27.000000000 +0100
++++ gnutls-patched/configure.ac	2020-09-10 09:26:43.000000000 +0100
+@@ -552,6 +552,9 @@
+ 
+ 
+ AC_LIB_HAVE_LINKFLAGS(dl,, [#include <dlfcn.h>], [dladdr (0, 0);])
++if test "x$HAVE_LIBDL" = "xyes"; then
++  AC_SUBST([LIBDL], [-ldl])
++fi
+ 
+ AC_ARG_ENABLE(fips140-mode,
+   AS_HELP_STRING([--enable-fips140-mode], [enable FIPS140-2 mode]),
+diff -ur gnutls/lib/gnutls.pc.in gnutls-patched/lib/gnutls.pc.in
+--- gnutls/lib/gnutls.pc.in	2020-08-30 14:58:51.000000000 +0100
++++ gnutls-patched/lib/gnutls.pc.in	2020-09-10 09:27:56.000000000 +0100
+@@ -19,6 +19,6 @@
+ URL: https://www.gnutls.org/
+ Version: @VERSION@
+ Libs: -L${libdir} -lgnutls
+-Libs.private: @LIBZ_PC@ @LIBINTL@ @LIBSOCKET@ @INET_PTON_LIB@ @LIBPTHREAD@ @LIB_SELECT@ @TSS_LIBS@ @GMP_LIBS@ @LIBUNISTRING@ @LIBATOMIC_LIBS@ @GNUTLS_LIBS_PRIVATE@
++Libs.private: @LIBZ_PC@ @LIBINTL@ @LIBSOCKET@ @INET_PTON_LIB@ @LIBPTHREAD@ @LIB_SELECT@ @TSS_LIBS@ @GMP_LIBS@ @LIBUNISTRING@ @LIBATOMIC_LIBS@ @GNUTLS_LIBS_PRIVATE@ @LIBDL@
+ @GNUTLS_REQUIRES_PRIVATE@
+ Cflags: -I${includedir}


### PR DESCRIPTION
webOS builds have been failing for some time. This was because gnutls was missing `-ldl` in linker flags causing ffmpeg to bail out at configure step. The patch was removed in #267 but it's actually still needed