### PR TITLE
README.md: Fix build status labels to report status for the Omega branch, not Nexus.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 [![License: GPL-2.0-or-later](https://img.shields.io/badge/License-GPL%20v2+-blue.svg)](LICENSE.md)
-[![Build Status](https://dev.azure.com/teamkodi/binary-addons/_apis/build/status/xbmc.inputstream.ffmpegdirect?branchName=Nexus)](https://dev.azure.com/teamkodi/binary-addons/_build/latest?definitionId=30&branchName=Nexus)
-[![Build Status](https://jenkins.kodi.tv/view/Addons/job/xbmc/job/inputstream.ffmpegdirect/job/Nexus/badge/icon)](https://jenkins.kodi.tv/blue/organizations/jenkins/xbmc%2Finputstream.ffmpegdirect/branches/)
+[![Build Status](https://dev.azure.com/teamkodi/binary-addons/_apis/build/status/xbmc.inputstream.ffmpegdirect?branchName=Omega)](https://dev.azure.com/teamkodi/binary-addons/_build/latest?definitionId=30&branchName=Omega)
+[![Build and run tests](https://github.com/xbmc/inputstream.ffmpegdirect/actions/workflows/build.yml/badge.svg?branch=Omega)](https://github.com/xbmc/inputstream.ffmpegdirect/actions/workflows/build.yml)
+[![Build Status](https://jenkins.kodi.tv/view/Addons/job/xbmc/job/inputstream.ffmpegdirect/job/Omega/badge/icon)](https://jenkins.kodi.tv/blue/organizations/jenkins/xbmc%2Finputstream.ffmpegdirect/branches/)
 
 # inputstream.ffmpegdirect addon for Kodi
 


### PR DESCRIPTION
Subject says it all. Just an oversight with the wrong branch I guess, and one label missing completely.