### PR TITLE
depends/libzvbi: Fix build where README file cannot be located 

### DIFF
--- a/depends/common/libzvbi/0010-fix-building-without-README.patch
+++ b/depends/common/libzvbi/0010-fix-building-without-README.patch
@@ -1,0 +1,27 @@
+From 2edb528dcbc848f9f9b3e11433a7d150d7351caa Mon Sep 17 00:00:00 2001
+From: Sam Nazarko <email@samnazarko.co.uk>
+Date: Sat, 11 May 2024 18:12:41 +0100
+Subject: [PATCH] Fix build where README file cannot be located by passing
+ foreign parameter to automake
+
+Signed-off-by: Sam Nazarko <email@samnazarko.co.uk>
+---
+ configure.ac | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/configure.ac b/configure.ac
+index 77d6aed..6432334 100644
+--- a/configure.ac
++++ b/configure.ac
+@@ -10,7 +10,7 @@ AC_CONFIG_MACRO_DIRS([m4])
+ AC_CONFIG_AUX_DIR(build-aux)
+ 
+ dnl Automake initialization
+-AM_INIT_AUTOMAKE([1.16 check-news dist-bzip2])
++AM_INIT_AUTOMAKE([1.16 check-news dist-bzip2 foreign])
+ 
+ dnl Store the host string without "unknown" for cross-compile use
+ host_str=$host
+-- 
+2.34.1
+


### PR DESCRIPTION
It looks like the build system expects a README file. This exists, but in the form README.md. I suspect this has been solved in a newer version of the library. 

There are two ways to fix this: 

* Either symlink README.MD to README, to keep autotools happy.
* Use AM_INIT_AUTOMAKE([foreign]) in configure.ac. 

There are a number of Automake files referencing the non-existent README file instead of the existing README.md file. I would suggest that such changes would be made upstream and there may even be a newer version of the library where this has been addressed.

This change simply relaxes Automake's requirements and means we don't have to unnecessarily bump and keep a stable version for Omega. 

This person also had a problem with Debian Buster: https://github.com/xbmc/inputstream.ffmpegdirect/issues/296 which should be fixed by this commit. I have verified this on Debian Bullseye.
 