### PR TITLE
Allow HTTP PROXY to be set via KODIPROP's

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,6 +157,10 @@ http://127.0.0.1:3002/mystream.m3u8
 - `timezone_shift`: The value in seconds to shift the catchup times by for your timezone. Valid values range from -43200 to 50400 (from -12 hours to +14 hours).
 - `default_programme_duration`: If the programme duration is unknown use this default value in seconds instead. If this value is not provided 4 hours (14,400 secs) will be used  will be used.
 - `programme_catchup_id`: For providers that require a programme specifc id the following value can be used in the url format string.
+- `http_proxy_host`: Host to use for http proxy. Note that the general add-on setting will be ignored if this used. All proxy properties must be set.
+- `http_proxy_port`: Port to use for http proxy. Note that the general add-on setting will be ignored if this used. All proxy properties must be set.
+- `http_proxy_user`: User to use for http proxy. Note that the general add-on setting will be ignored if this used. All proxy properties must be set.
+- `http_proxy_password`: Password to use for http proxy. Note that the general add-on setting will be ignored if this used. All proxy properties must be set.
 
 **Notes:**
 - Setting `playback_as_live` to `true` only makes sense when the catchup start and end times are set to the size of the catchup windows (e.g. 3 days). If the catchup start and end times are set to the programme times then `playback_as_live` will have little effect.

--- a/inputstream.ffmpegdirect/addon.xml.in
+++ b/inputstream.ffmpegdirect/addon.xml.in
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <addon
   id="inputstream.ffmpegdirect"
-  version="22.0.1"
+  version="22.1.0"
   name="Inputstream FFmpeg Direct"
   provider-name="Ross Nicholson">
   <requires>@ADDON_DEPENDS@</requires>

--- a/inputstream.ffmpegdirect/addon.xml.in
+++ b/inputstream.ffmpegdirect/addon.xml.in
@@ -10,7 +10,7 @@
     name="ffmpegdirect"
     extension=""
     tags="true"
-    listitemprops="program_number|stream_mode|open_mode|manifest_type|default_url|is_realtime_stream|playback_as_live|programme_start_time|programme_end_time|catchup_url_format_string|catchup_url_near_live_format_string|catchup_buffer_start_time|catchup_buffer_end_time|catchup_buffer_offset|catchup_terminates|catchup_granularity|timezone_shift|default_programme_duration|programme_catchup_id"
+    listitemprops="program_number|stream_mode|open_mode|manifest_type|default_url|is_realtime_stream|playback_as_live|programme_start_time|programme_end_time|catchup_url_format_string|catchup_url_near_live_format_string|catchup_buffer_start_time|catchup_buffer_end_time|catchup_buffer_offset|catchup_terminates|catchup_granularity|timezone_shift|default_programme_duration|programme_catchup_id|http_proxy_host|http_proxy_port|http_proxy_user|http_proxy_password"
     library_@PLATFORM@="@LIBRARY_FILENAME@" />
   <extension point="xbmc.service" library="resources/lib/runner.py"/>
   <extension point="xbmc.addon.metadata">

--- a/inputstream.ffmpegdirect/changelog.txt
+++ b/inputstream.ffmpegdirect/changelog.txt
@@ -1,3 +1,7 @@
+v22.1.0
+- Allow HTTP PROXY to be set via KODIPROP's
+- Allow http_proxy to be set via URL arguemnt using pipe
+
 v22.0.1
 - Add patch for pthread create and compile option for Android NDK 26 compatibility with libzvbi
 - Disable vulkan in ffmpeg for Android as NDK 26 doesn't have vulkan_beta.h

--- a/src/StreamManager.cpp
+++ b/src/StreamManager.cpp
@@ -65,6 +65,8 @@ bool InputStreamFFmpegDirect::Open(const kodi::addon::InputstreamProperty& props
 {
   Log(LOGLEVEL_INFO, "inputstream.ffmpegdirect: OpenStream() - Num Props: %d", props.GetPropertiesAmount());
 
+  HttpProxy httpProxy;
+
   for (const auto& prop : props.GetProperties())
   {
     if (StringUtils::StartsWith(prop.second, "http://") || StringUtils::StartsWith(prop.second, "https://"))
@@ -154,6 +156,25 @@ bool InputStreamFFmpegDirect::Open(const kodi::addon::InputstreamProperty& props
     {
       m_properties.m_programmeCatchupId = prop.second;
     }
+    else if (HTTP_PROXY_HOST == prop.first)
+    {
+      httpProxy.SetProxyHost(prop.second);
+      kodi::Log(ADDON_LOG_INFO, "HttpProxy host set vis KODIPROP: '%s'", httpProxy.GetProxyHost().c_str());
+    }
+    else if (HTTP_PROXY_PORT == prop.first)
+    {
+      httpProxy.SetProxyPort(std::atoi(prop.second.c_str()));
+      kodi::Log(ADDON_LOG_INFO, "HttpProxy port set as KODIPROP: %d", static_cast<int>(httpProxy.GetProxyPort()));
+    }
+    else if (HTTP_PROXY_USER == prop.first)
+    {
+      httpProxy.SetProxyUser(prop.second);
+      kodi::Log(ADDON_LOG_INFO, "HttpProxy user set as KODIPROP: '%s'", httpProxy.GetProxyUser().c_str());
+    }
+    else if (HTTP_PROXY_PASSWORD == prop.first)
+    {
+      httpProxy.SetProxyPassword(prop.second);
+    }
   }
 
   m_streamUrl = props.GetURL();
@@ -190,10 +211,8 @@ bool InputStreamFFmpegDirect::Open(const kodi::addon::InputstreamProperty& props
       m_properties.m_openMode = OpenMode::CURL;
   }
 
-  HttpProxy httpProxy;
-
   bool useHttpProxy = kodi::addon::GetSettingBoolean("useHttpProxy");
-  if (useHttpProxy)
+  if (useHttpProxy && !httpProxy.GetProxyHost().empty()) // If a proxy host as not been set as a KODIPROP
   {
     httpProxy.SetProxyHost(kodi::addon::GetSettingString("httpProxyHost"));
     kodi::Log(ADDON_LOG_INFO, "HttpProxy host set: '%s'", httpProxy.GetProxyHost().c_str());

--- a/src/StreamManager.h
+++ b/src/StreamManager.h
@@ -35,6 +35,10 @@ static const std::string CATCHUP_GRANULARITY = "inputstream.ffmpegdirect.catchup
 static const std::string TIMEZONE_SHIFT = "inputstream.ffmpegdirect.timezone_shift";
 static const std::string DEFAULT_PROGRAMME_DURATION = "inputstream.ffmpegdirect.default_programme_duration";
 static const std::string PROGRAMME_CATCHUP_ID = "inputstream.ffmpegdirect.programme_catchup_id";
+static const std::string HTTP_PROXY_HOST = "inputstream.ffmpegdirect.http_proxy_host";
+static const std::string HTTP_PROXY_PORT = "inputstream.ffmpegdirect.http_proxy_port";
+static const std::string HTTP_PROXY_USER = "inputstream.ffmpegdirect.http_proxy_user";
+static const std::string HTTP_PROXY_PASSWORD = "inputstream.ffmpegdirect.http_proxy_password";
 
 class ATTR_DLL_LOCAL InputStreamFFmpegDirect
   : public kodi::addon::CInstanceInputStream, ffmpegdirect::IManageDemuxPacket

--- a/src/stream/FFmpegStream.cpp
+++ b/src/stream/FFmpegStream.cpp
@@ -2360,7 +2360,8 @@ AVDictionary* FFmpegStream::GetFFMpegOptionsFromInput()
       // set any of these ffmpeg options
       if (name == "seekable" || name == "reconnect" || name == "reconnect_at_eof" ||
           name == "reconnect_streamed" || name == "reconnect_delay_max" ||
-          name == "icy" || name == "icy_metadata_headers" || name == "icy_metadata_packet" || name == "cenc_decryption_key")
+          name == "icy" || name == "icy_metadata_headers" || name == "icy_metadata_packet" || name == "cenc_decryption_key" ||
+          name == "http_proxy")
       {
         Log(LOGLEVEL_DEBUG,
                   "CDVDDemuxFFmpeg::GetFFMpegOptionsFromInput() adding ffmpeg option '%s: %s'",

--- a/src/stream/FFmpegStream.cpp
+++ b/src/stream/FFmpegStream.cpp
@@ -2367,6 +2367,10 @@ AVDictionary* FFmpegStream::GetFFMpegOptionsFromInput()
                   "CDVDDemuxFFmpeg::GetFFMpegOptionsFromInput() adding ffmpeg option '%s: %s'",
                   it->first.c_str(), value.c_str());
         av_dict_set(&options, name.c_str(), value.c_str(), 0);
+        if (name == "http_proxy")
+          Log(LOGLEVEL_ERROR,
+                  "XXX CDVDDemuxFFmpeg::GetFFMpegOptionsFromInput() adding ffmpeg option '%s: %s'",
+                  name.c_str(), value.c_str());
       }
       // map some standard http headers to the ffmpeg related options
       else if (name == "user-agent")


### PR DESCRIPTION
v22.1.0
- Allow HTTP PROXY to be set via KODIPROP's
- Allow http_proxy to be set via URL arguemnt using pipe

New KODIPROP values:
- `inputstream.ffmpegdirect.http_proxy_host`
- `inputstream.ffmpegdirect.http_proxy_port`
- `inputstream.ffmpegdirect.http_proxy_user`
- `inputstream.ffmpegdirect.http_proxy_password`

Also permits the proxy to be set using the `http_proxy` proprty after a `|` in the URL, e.g.

```
https://example.com/index.m3u8|http_proxy=http://username:password@127.0.0.1:8081
```