### PR TITLE
Put CVariant into own namespace

### DIFF
--- a/inputstream.ffmpegdirect/addon.xml.in
+++ b/inputstream.ffmpegdirect/addon.xml.in
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <addon
   id="inputstream.ffmpegdirect"
-  version="22.1.0"
+  version="22.1.1"
   name="Inputstream FFmpeg Direct"
   provider-name="Ross Nicholson">
   <requires>@ADDON_DEPENDS@</requires>

--- a/inputstream.ffmpegdirect/changelog.txt
+++ b/inputstream.ffmpegdirect/changelog.txt
@@ -1,3 +1,6 @@
+v22.1.1
+- Move CVariant to ffmpegdirect namespace to avoid collision with CVariant in Kodi, which causes random crashes when playing streams with this addon.
+
 v22.1.0
 - Bump ffmpeg to 7.1 and add patch to fix build on aarch64 targeting ios/tvos
 - Bump gnutls to 3.8.8 and add patch to fix build on Android NDK r27+

--- a/src/stream/url/URL.cpp
+++ b/src/stream/url/URL.cpp
@@ -25,6 +25,7 @@
 #include <kodi/tools/StringUtils.h>
 
 using namespace kodi::tools;
+using namespace ffmpegdirect;
 //using namespace ADDON;
 
 namespace

--- a/src/stream/url/UrlOptions.cpp
+++ b/src/stream/url/UrlOptions.cpp
@@ -157,7 +157,7 @@ bool CUrlOptions::HasOption(const std::string &key) const
   return m_options.find(key) != m_options.end();
 }
 
-bool CUrlOptions::GetOption(const std::string &key, CVariant &value) const
+bool CUrlOptions::GetOption(const std::string &key, ffmpegdirect::CVariant &value) const
 {
   if (key.empty())
     return false;

--- a/src/stream/url/UrlOptions.h
+++ b/src/stream/url/UrlOptions.h
@@ -15,7 +15,7 @@
 class CUrlOptions
 {
 public:
-  typedef std::map<std::string, CVariant> UrlOptions;
+  typedef std::map<std::string, ffmpegdirect::CVariant> UrlOptions;
 
   CUrlOptions();
   CUrlOptions(const std::string &options, const char *strLead = "");
@@ -37,7 +37,7 @@ public:
   virtual void RemoveOption(const std::string &key);
 
   bool HasOption(const std::string &key) const;
-  bool GetOption(const std::string &key, CVariant &value) const;
+  bool GetOption(const std::string &key, ffmpegdirect::CVariant &value) const;
 
 protected:
   UrlOptions m_options;

--- a/src/stream/url/Variant.cpp
+++ b/src/stream/url/Variant.cpp
@@ -11,6 +11,8 @@
 #include <string.h>
 #include <utility>
 
+using namespace ffmpegdirect;
+
 #ifndef strtoll
 #ifdef TARGET_WINDOWS
 #define strtoll  _strtoi64

--- a/src/stream/url/Variant.h
+++ b/src/stream/url/Variant.h
@@ -25,6 +25,8 @@ double str2double(const std::wstring &str, double fallback = 0.0);
 #pragma pack(8)
 #endif
 
+namespace ffmpegdirect {
+
 class CVariant
 {
 public:
@@ -161,6 +163,8 @@ private:
   static VariantArray EMPTY_ARRAY;
   static VariantMap EMPTY_MAP;
 };
+
+} // namespace ffmpegdirect
 
 #ifdef TARGET_WINDOWS_STORE
 #pragma pack(pop)

--- a/src/stream/url/Variant.h
+++ b/src/stream/url/Variant.h
@@ -25,8 +25,8 @@ double str2double(const std::wstring &str, double fallback = 0.0);
 #pragma pack(8)
 #endif
 
-namespace ffmpegdirect {
-
+namespace ffmpegdirect
+{
 class CVariant
 {
 public:


### PR DESCRIPTION
Put CVariant into ffmpegdirect namespace to avoid collisions with CVariant in XBMC tree.
This fixes Kodi crashes as described in https://github.com/xbmc/inputstream.ffmpegdirect/issues/319