### PR TITLE
[Windows] Fix openssl build (missing strawberryperl in path)

### DIFF
--- a/depends/windows/openssl/01-openssl.patch
+++ b/depends/windows/openssl/01-openssl.patch
@@ -1,6 +1,6 @@
 --- /dev/null
 +++ b/CMakeLists.txt
-@@ -0,0 +1,107 @@
+@@ -0,0 +1,110 @@
 +cmake_minimum_required(VERSION 3.0)
 +
 +project(openssl VERSION 1.1.1 LANGUAGES C)
@@ -10,6 +10,9 @@
 +check_symbol_exists(_AMD64_ "Windows.h" _AMD64_)
 +check_symbol_exists(_ARM_ "Windows.h" _ARM_)
 +check_symbol_exists(_ARM64_ "Windows.h" _ARM64_)
++
++find_package(StrawberryPerl REQUIRED)
++set(ENV{PATH} "${STRAWBERRYPERL_PATH};$ENV{PATH}")
 +
 +if(_X86_)
 +	message(STATUS "Win32")


### PR DESCRIPTION
https://github.com/xbmc/inputstream.ffmpegdirect/commit/6bb9461462594d7701d1e43e965ca1ce3c1dca29 added this change in

But them seems it was removed (by accident?) in the commit updating openssl
https://github.com/xbmc/inputstream.ffmpegdirect/commit/fdf272892dfeb63e913640af1b07bf673192831e