### PR TITLE
Fix logging (Crash on % user-agents) [Piers]

### DIFF
--- a/inputstream.ffmpegdirect/addon.xml.in
+++ b/inputstream.ffmpegdirect/addon.xml.in
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <addon
   id="inputstream.ffmpegdirect"
-  version="22.1.1"
+  version="22.1.2"
   name="Inputstream FFmpeg Direct"
   provider-name="Ross Nicholson">
   <requires>@ADDON_DEPENDS@</requires>

--- a/inputstream.ffmpegdirect/changelog.txt
+++ b/inputstream.ffmpegdirect/changelog.txt
@@ -1,3 +1,7 @@
+v22.1.2
+- Fix crashing when % in headers caused by missing kodi::Log format arg
+- Fix building of openssl on windows caused by missing strawberryperl in path
+
 v22.1.1
 - Move CVariant to ffmpegdirect namespace to avoid collision with CVariant in Kodi, which causes random crashes when playing streams with this addon.
 

--- a/src/StreamManager.cpp
+++ b/src/StreamManager.cpp
@@ -49,7 +49,7 @@ void Log(const LogLevel logLevel, const char* format, ...)
   va_start(args, format);
   vsnprintf(buffer, sizeof(buffer), format, args);
   va_end(args);
-  kodi::Log(addonLevel, buffer);
+  kodi::Log(addonLevel, "%s", buffer);
 }
 
 InputStreamFFmpegDirect::InputStreamFFmpegDirect(const kodi::addon::IInstanceInfo& instance)


### PR DESCRIPTION
Fixes:
https://github.com/xbmc/inputstream.ffmpegdirect/issues/229
https://github.com/xbmc/inputstream.ffmpegdirect/issues/323

Have run time tested on Piers with below test strm
```
#EXTINF:-1, Video item
#KODIPROP:inputstream=inputstream.ffmpegdirect
#KODIPROP:inputstream.ffmpegdirect.is_realtime_stream=true
https://d32ubfwfcm754e.cloudfront.net/master_1.m3u8|User-Agent=otg%2F1.5.1%20%28AppleTv%20Apple%20TV%204%3B%20tvOS16.0%3B%20appletv.client%29%20libcurl%2F7.58.0%20OpenSSL%2F1.0.2o%20zlib%2F1.2.11%20clib%2F1.8.56
```

I assume when we had % in our buffer, kodi:log was trying to use them as the format (its 2nd argument)
![image](https://github.com/user-attachments/assets/25cad0d2-4df7-4aef-8b26-1edfd7755a75)
![image](https://github.com/user-attachments/assets/e8efcaa7-2553-4e28-bead-2c4df48eb38c)


This broke between Matrix and Nexus
Looking at Matrix, it used
https://github.com/xbmc/inputstream.ffmpegdirect/blob/Matrix/src/StreamManager.cpp
::kodi::addon::CAddonBase::m_interface->toKodi->addon_log_msg(::kodi::addon::CAddonBase::m_interface->toKodi->kodiBase, addonLevel, buffer);

Nexus then used
kodi::Log(addonLevel, buffer);

Assume just in the swap it was missed that the arguments changed for the new method :)
The new method can do the formatting as well so expects a "format"