### PR TITLE
Fix logging (Crash on % user-agents) [Omega]

### DIFF
--- a/inputstream.ffmpegdirect/addon.xml.in
+++ b/inputstream.ffmpegdirect/addon.xml.in
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <addon
   id="inputstream.ffmpegdirect"
-  version="21.3.7"
+  version="21.3.8"
   name="Inputstream FFmpeg Direct"
   provider-name="Ross Nicholson">
   <requires>@ADDON_DEPENDS@</requires>

--- a/inputstream.ffmpegdirect/changelog.txt
+++ b/inputstream.ffmpegdirect/changelog.txt
@@ -1,3 +1,6 @@
+v21.3.6
+- Fix crashing when % in headers caused by missing kodi::Log format arg
+
 v21.3.5
 - Update depednencies to fix building on apple silicon (gnutls 3.8.4) and binutils on linux (2.41 or higher)
 

--- a/src/StreamManager.cpp
+++ b/src/StreamManager.cpp
@@ -49,7 +49,7 @@ void Log(const LogLevel logLevel, const char* format, ...)
   va_start(args, format);
   vsnprintf(buffer, sizeof(buffer), format, args);
   va_end(args);
-  kodi::Log(addonLevel, buffer);
+  kodi::Log(addonLevel, "%s", buffer);
 }
 
 InputStreamFFmpegDirect::InputStreamFFmpegDirect(const kodi::addon::IInstanceInfo& instance)


### PR DESCRIPTION
Backport of https://github.com/xbmc/inputstream.ffmpegdirect/pull/326

Have run time tested on Omega with below test strm
```
#EXTINF:-1, Video item
#KODIPROP:inputstream=inputstream.ffmpegdirect
#KODIPROP:inputstream.ffmpegdirect.is_realtime_stream=true
https://d32ubfwfcm754e.cloudfront.net/master_1.m3u8|User-Agent=otg%2F1.5.1%20%28AppleTv%20Apple%20TV%204%3B%20tvOS16.0%3B%20appletv.client%29%20libcurl%2F7.58.0%20OpenSSL%2F1.0.2o%20zlib%2F1.2.11%20clib%2F1.8.56
```