### PR TITLE
Fix logging (Crash on % user-agents) [Nexus]

### DIFF
--- a/src/StreamManager.cpp
+++ b/src/StreamManager.cpp
@@ -49,7 +49,7 @@ void Log(const LogLevel logLevel, const char* format, ...)
   va_start(args, format);
   vsprintf(buffer, format, args);
   va_end(args);
-  kodi::Log(addonLevel, buffer);
+  kodi::Log(addonLevel, "%s", buffer);
 }
 
 InputStreamFFmpegDirect::InputStreamFFmpegDirect(const kodi::addon::IInstanceInfo& instance)


### PR DESCRIPTION
backport https://github.com/xbmc/inputstream.ffmpegdirect/pull/326

not sure if still doing Nexus releases, but having this PR ready in case you are