### PR TITLE
Tag version 22.1.4

### DIFF
--- a/inputstream.ffmpegdirect/addon.xml.in
+++ b/inputstream.ffmpegdirect/addon.xml.in
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <addon
   id="inputstream.ffmpegdirect"
-  version="22.1.3"
+  version="22.1.4"
   name="Inputstream FFmpeg Direct"
   provider-name="Ross Nicholson">
   <requires>@ADDON_DEPENDS@</requires>

--- a/inputstream.ffmpegdirect/changelog.txt
+++ b/inputstream.ffmpegdirect/changelog.txt
@@ -1,3 +1,9 @@
+v22.1.4
+- Kodi inputstream API update to version 3.4.0
+- gmp: download from GNU Mirror
+- Update dependency libiconv to version 1.18
+- curl: use namespace ffmpegdirect to fix name clash
+
 v22.1.2
 - Fix crashing when % in headers caused by missing kodi::Log format arg
 - Fix building of openssl on windows caused by missing strawberryperl in path


### PR DESCRIPTION
As requested by @CastagnaIT 

Required to bump version of addon as inputstream API increasing to v3.4.0 when the following PR is merged:

https://github.com/xbmc/xbmc/pull/27136