### PR TITLE
class CURL: use namespace ffmpegdirect to fix name clash

### DIFF
--- a/src/stream/url/URL.h
+++ b/src/stream/url/URL.h
@@ -16,6 +16,8 @@
 #undef SetPort // WIN32INCLUDES this is defined as SetPortA in WinSpool.h which is being included _somewhere_
 #endif
 
+namespace ffmpegdirect
+{
 class CURL
 {
 public:
@@ -199,3 +201,4 @@ protected:
   CUrlOptions m_options;
   CUrlOptions m_protocolOptions;
 };
+} // namespace ffmpegdirect

--- a/src/stream/url/UrlOptions.cpp
+++ b/src/stream/url/UrlOptions.cpp
@@ -13,6 +13,7 @@
 #include <kodi/tools/StringUtils.h>
 
 using namespace kodi::tools;
+using namespace ffmpegdirect;
 
 CUrlOptions::CUrlOptions() = default;
 


### PR DESCRIPTION
Fix CURL name clash seen in current LE13 nightly builds.

Wrong CURL constructor from kodi xbmc/URL.h:24 was used in FmpegStream::GetFFMpegOptionsFromInput() (of src/stream/FFmpegStream.cpp:2282) causing a crash in following url.Parse(m_streamUrl).

### Motivation and context
Crash was reported in [LE forum](https://forum.libreelec.tv/thread/29977-x86-64-iptv-simple-crash-report/). Beside the reported crashes using pvr.iptvsimple or pvr.nextpvr I was able to reproduce it with a .strm file playing a FTA (but geoblocked) dash stream.

GDB showed wrong curl constructor. With using already existing ffmpegdirect namespace the crash disappeared (confirmed in forum).