### PR TITLE
DVDDemuxFFmpeg: New addon setting to set ffmpeg option 'extension_picky'

### DIFF
--- a/inputstream.ffmpegdirect/resources/language/resource.language.en_gb/strings.po
+++ b/inputstream.ffmpegdirect/resources/language/resource.language.en_gb/strings.po
@@ -133,8 +133,12 @@ msgctxt "#30046"
 msgid "For catchup streams report stream is not realtime"
 msgstr ""
 
-#empty strings from id 30047 to 30599
+#. help: Advanced - disableStrictHLSfileExtensionCheck
+msgctxt "#30047"
+msgid "Disable strict HLS file extension check"
+msgstr ""
 
+# empty strings from id 30048 to 30599
 #. ############
 #. help info #
 #. ############
@@ -232,4 +236,9 @@ msgstr ""
 #. help: Advanced - forceRealtimeOffCatchup
 msgctxt "#30645"
 msgid "For certain catchup streams such as HLS reporting that a live stream is not live can improve stream open times. If testing this option works for a catchup stream/provider, then add a [I]\"#KODIPROP=inputstream.ffmpegdirect.is_realtime_stream=false\"[/I] to the M3U entry in question. This setting should not be left enabled for all streams."
+msgstr ""
+
+#. help: Advanced - disableStrictHLSfileExtensionCheck
+msgctxt "#30646"
+msgid "Allows playing HLS streams without file extension or with unsuported file extension. This lowers the security requirements in ffmpeg."
 msgstr ""

--- a/inputstream.ffmpegdirect/resources/settings.xml
+++ b/inputstream.ffmpegdirect/resources/settings.xml
@@ -140,6 +140,11 @@
           <default>false</default>
           <control type="toggle" />
         </setting>
+        <setting id="disableStrictHLSfileExtensionCheck" type="boolean" label="30047" help="30646">
+          <level>2</level>
+          <default>false</default>
+          <control type="toggle" />
+        </setting>
       </group>
     </category>
   </section>

--- a/src/stream/FFmpegStream.cpp
+++ b/src/stream/FFmpegStream.cpp
@@ -2287,6 +2287,10 @@ AVDictionary* FFmpegStream::GetFFMpegOptionsFromInput()
   if (url.GetProtocol().empty() || url.IsProtocol("file"))
     av_dict_set(&options, "protocol_whitelist", "file,http,https,tcp,tls,crypto", 0);
 
+  // Disable strict HLS file extension check
+  if (kodi::addon::GetSettingBoolean("disableStrictHLSfileExtensionCheck"))
+    av_dict_set(&options, "extension_picky", "0", 0);
+
   if (url.IsProtocol("http") || url.IsProtocol("https"))
   {
     std::map<std::string, std::string> protocolOptions;


### PR DESCRIPTION
allows to play HLS stream without extension in url
related to https://github.com/FFmpeg/FFmpeg/commit/b753bac08f6881b2d3dea8f1ab84c81550f35897

`2025-10-16 18:51:56.563 T:885     error <general>: ffmpeg[0x6ff2e90]: [hls] URL https://some.server.com/stream/fragment/ts/live/?session=163ec3ad-7f2e-4f16-be20-062a73733b56&offset=192639&pointeroffset=39&fragmentlength=4800 is not in allowed_extensions`