### PR TITLE
DVDDemuxFFmpeg: set namespace for UrlOptions class

### DIFF
--- a/src/stream/url/UrlOptions.h
+++ b/src/stream/url/UrlOptions.h
@@ -12,6 +12,8 @@
 #include <map>
 #include <string>
 
+namespace ffmpegdirect
+{
 class CUrlOptions
 {
 public:
@@ -43,3 +45,4 @@ protected:
   UrlOptions m_options;
   std::string m_strLead;
 };
+} // namespace ffmpegdirect


### PR DESCRIPTION
also related to #344 but fixes generic problem passing a value

use correct class methods from ffmpegdirect UrlOptions.cpp and not from Kodi which uses same class name
now the ffmpeg option value is passed to ffmpeg

before
`2025-10-31 18:29:33.622 T:10030   debug <inputstream.ffmpegdirect>: CDVDDemuxFFmpeg::GetFFMpegOptionsFromInput() adding ffmpeg option 'extension_picky: '`
after
`2025-10-31 18:31:16.884 T:10126   debug <inputstream.ffmpegdirect>: CDVDDemuxFFmpeg::GetFFMpegOptionsFromInput() adding ffmpeg option 'extension_picky: 0'`