### PR TITLE
webOS: Link zvbi_conf to iconv

### DIFF
--- a/depends/common/libzvbi/CMakeLists.txt
+++ b/depends/common/libzvbi/CMakeLists.txt
@@ -12,7 +12,7 @@ else()
   list(APPEND zvbi_conf CFLAGS=-I${CMAKE_INSTALL_PREFIX}/include)
 endif()
 list(APPEND zvbi_conf LDFLAGS=-L${CMAKE_INSTALL_PREFIX}/lib)
-if (CORE_SYSTEM_NAME STREQUAL android)
+if ((CORE_SYSTEM_NAME STREQUAL android) OR (CMAKE_CXX_COMPILER MATCHES arm-webos))
   list(APPEND zvbi_conf LIBS=-liconv)
 endif()
 


### PR DESCRIPTION
Hopefully fixes this issue with the kodi webos-docker, however I cannot test this it does not occur locally:

```
configure: WARNING: using cross tools not prefixed with host triplet
/home/jenkins/webos-tools/arm-webos-linux-gnueabi_sdk-buildroot/bin/../lib/gcc/arm-webos-linux-gnueabi/12.2.0/../../../../arm-webos-linux-gnueabi/bin/ld: ../src/.libs/libzvbi.a(conv.o): in function `iconv_ucs2':
conv.c:(.text+0x98): undefined reference to `libiconv'
/home/jenkins/webos-tools/arm-webos-linux-gnueabi_sdk-buildroot/bin/../lib/gcc/arm-webos-linux-gnueabi/12.2.0/../../../../arm-webos-linux-gnueabi/bin/ld: conv.c:(.text+0xf4): undefined reference to `libiconv'
/home/jenkins/webos-tools/arm-webos-linux-gnueabi_sdk-buildroot/bin/../lib/gcc/arm-webos-linux-gnueabi/12.2.0/../../../../arm-webos-linux-gnueabi/bin/ld: ../src/.libs/libzvbi.a(conv.o): in function `_vbi_iconv_close':
conv.c:(.text+0x184): undefined reference to `libiconv_close'
/home/jenkins/webos-tools/arm-webos-linux-gnueabi_sdk-buildroot/bin/../lib/gcc/arm-webos-linux-gnueabi/12.2.0/../../../../arm-webos-linux-gnueabi/bin/ld: ../src/.libs/libzvbi.a(conv.o): in function `_vbi_iconv_open':
conv.c:(.text+0x1dc): undefined reference to `libiconv_open'
/home/jenkins/webos-tools/arm-webos-linux-gnueabi_sdk-buildroot/bin/../lib/gcc/arm-webos-linux-gnueabi/12.2.0/../../../../arm-webos-linux-gnueabi/bin/ld: conv.c:(.text+0x22c): undefined reference to `libiconv'
/home/jenkins/webos-tools/arm-webos-linux-gnueabi_sdk-buildroot/bin/../lib/gcc/arm-webos-linux-gnueabi/12.2.0/../../../../arm-webos-linux-gnueabi/bin/ld: ../src/.libs/libzvbi.a(conv.o): in function `_vbi_strndup_iconv':
conv.c:(.text+0x86c): undefined reference to `libiconv'
collect2: error: ld returned 1 exit status
make[10]: *** [Makefile:532: zvbi-ntsc-cc] Error 1
make[10]: *** Waiting for unfinished jobs....
/home/jenkins/webos-tools/arm-webos-linux-gnueabi_sdk-buildroot/bin/../lib/gcc/arm-webos-linux-gnueabi/12.2.0/../../../../arm-webos-linux-gnueabi/bin/ld: ../src/.libs/libzvbi.a(export.o): in function `vbi_ucs2be':
export.c:(.text+0x190): undefined reference to `libiconv_open'
/home/jenkins/webos-tools/arm-webos-linux-gnueabi_sdk-buildroot/bin/../lib/gcc/arm-webos-linux-gnueabi/12.2.0/../../../../arm-webos-linux-gnueabi/bin/ld: export.c:(.text+0x1b8): undefined reference to `libiconv'
/home/jenkins/webos-tools/arm-webos-linux-gnueabi_sdk-buildroot/bin/../lib/gcc/arm-webos-linux-gnueabi/12.2.0/../../../../arm-webos-linux-gnueabi/bin/ld: export.c:(.text+0x1dc): undefined reference to `libiconv_close'
/home/jenkins/webos-tools/arm-webos-linux-gnueabi_sdk-buildroot/bin/../lib/gcc/arm-webos-linux-gnueabi/12.2.0/../../../../arm-webos-linux-gnueabi/bin/ld: ../src/.libs/libzvbi.a(conv.o): in function `iconv_ucs2':
conv.c:(.text+0x98): undefined reference to `libiconv'
/home/jenkins/webos-tools/arm-webos-linux-gnueabi_sdk-buildroot/bin/../lib/gcc/arm-webos-linux-gnueabi/12.2.0/../../../../arm-webos-linux-gnueabi/bin/ld: conv.c:(.text+0xf4): undefined reference to `libiconv'
/home/jenkins/webos-tools/arm-webos-linux-gnueabi_sdk-buildroot/bin/../lib/gcc/arm-webos-linux-gnueabi/12.2.0/../../../../arm-webos-linux-gnueabi/bin/ld: ../src/.libs/libzvbi.a(conv.o): in function `_vbi_iconv_close':
conv.c:(.text+0x184): undefined reference to `libiconv_close'
/home/jenkins/webos-tools/arm-webos-linux-gnueabi_sdk-buildroot/bin/../lib/gcc/arm-webos-linux-gnueabi/12.2.0/../../../../arm-webos-linux-gnueabi/bin/ld: ../src/.libs/libzvbi.a(conv.o): in function `_vbi_iconv_open':
conv.c:(.text+0x1dc): undefined reference to `libiconv_open'
/home/jenkins/webos-tools/arm-webos-linux-gnueabi_sdk-buildroot/bin/../lib/gcc/arm-webos-linux-gnueabi/12.2.0/../../../../arm-webos-linux-gnueabi/bin/ld: conv.c:(.text+0x22c): undefined reference to `libiconv'
/home/jenkins/webos-tools/arm-webos-linux-gnueabi_sdk-buildroot/bin/../lib/gcc/arm-webos-linux-gnueabi/12.2.0/../../../../arm-webos-linux-gnueabi/bin/ld: ../src/.libs/libzvbi.a(conv.o): in function `_vbi_strndup_iconv':
conv.c:(.text+0x86c): undefined reference to `libiconv'
/home/jenkins/webos-tools/arm-webos-linux-gnueabi_sdk-buildroot/bin/../lib/gcc/arm-webos-linux-gnueabi/12.2.0/../../../../arm-webos-linux-gnueabi/bin/ld: ../src/.libs/libzvbi.a(exp-html.o): in function `export':
exp-html.c:(.text+0x7b8): undefined reference to `libiconv_open'
/home/jenkins/webos-tools/arm-webos-linux-gnueabi_sdk-buildroot/bin/../lib/gcc/arm-webos-linux-gnueabi/12.2.0/../../../../arm-webos-linux-gnueabi/bin/ld: exp-html.c:(.text+0xc74): undefined reference to `libiconv_close'
/home/jenkins/webos-tools/arm-webos-linux-gnueabi_sdk-buildroot/bin/../lib/gcc/arm-webos-linux-gnueabi/12.2.0/../../../../arm-webos-linux-gnueabi/bin/ld: exp-html.c:(.text+0x103c): undefined reference to `libiconv'
/home/jenkins/webos-tools/arm-webos-linux-gnueabi_sdk-buildroot/bin/../lib/gcc/arm-webos-linux-gnueabi/12.2.0/../../../../arm-webos-linux-gnueabi/bin/ld: exp-html.c:(.text+0x1228): undefined reference to `libiconv_close'
/home/jenkins/webos-tools/arm-webos-linux-gnueabi_sdk-buildroot/bin/../lib/gcc/arm-webos-linux-gnueabi/12.2.0/../../../../arm-webos-linux-gnueabi/bin/ld: ../src/.libs/libzvbi.a(exp-txt.o): in function `print_unicode':
exp-txt.c:(.text+0x134): undefined reference to `libiconv'
/home/jenkins/webos-tools/arm-webos-linux-gnueabi_sdk-buildroot/bin/../lib/gcc/arm-webos-linux-gnueabi/12.2.0/../../../../arm-webos-linux-gnueabi/bin/ld: exp-txt.c:(.text+0x1b0): undefined reference to `libiconv'
/home/jenkins/webos-tools/arm-webos-linux-gnueabi_sdk-buildroot/bin/../lib/gcc/arm-webos-linux-gnueabi/12.2.0/../../../../arm-webos-linux-gnueabi/bin/ld: ../src/.libs/libzvbi.a(exp-txt.o): in function `export':
exp-txt.c:(.text+0x22c): undefined reference to `libiconv_open'
/home/jenkins/webos-tools/arm-webos-linux-gnueabi_sdk-buildroot/bin/../lib/gcc/arm-webos-linux-gnueabi/12.2.0/../../../../arm-webos-linux-gnueabi/bin/ld: exp-txt.c:(.text+0x26c): undefined reference to `libiconv_close'
/home/jenkins/webos-tools/arm-webos-linux-gnueabi_sdk-buildroot/bin/../lib/gcc/arm-webos-linux-gnueabi/12.2.0/../../../../arm-webos-linux-gnueabi/bin/ld: exp-txt.c:(.text+0x308): undefined reference to `libiconv_close'
/home/jenkins/webos-tools/arm-webos-linux-gnueabi_sdk-buildroot/bin/../lib/gcc/arm-webos-linux-gnueabi/12.2.0/../../../../arm-webos-linux-gnueabi/bin/ld: ../src/.libs/libzvbi.a(exp-txt.o): in function `vbi_print_page_region':
exp-txt.c:(.text+0xaf0): undefined reference to `libiconv_open'
/home/jenkins/webos-tools/arm-webos-linux-gnueabi_sdk-buildroot/bin/../lib/gcc/arm-webos-linux-gnueabi/12.2.0/../../../../arm-webos-linux-gnueabi/bin/ld: exp-txt.c:(.text+0xb2c): undefined reference to `libiconv_close'
/home/jenkins/webos-tools/arm-webos-linux-gnueabi_sdk-buildroot/bin/../lib/gcc/arm-webos-linux-gnueabi/12.2.0/../../../../arm-webos-linux-gnueabi/bin/ld: exp-txt.c:(.text+0xc78): undefined reference to `libiconv_close'
collect2: error: ld returned 1 exit status
make[10]: *** [Makefile:524: x11font] Error 1
make[9]: *** [Makefile:522: all-recursive] Error 1
make[8]: *** [Makefile:429: all] Error 2
make[7]: *** [CMakeFiles/libzvbi.dir/build.make:86: libzvbi-prefix/src/libzvbi-stamp/libzvbi-build] Error 2
make[6]: *** [CMakeFiles/Makefile2:87: CMakeFiles/libzvbi.dir/all] Error 2
make[5]: *** [Makefile:136: all] Error 2
make[4]: *** [CMakeFiles/libzvbi.dir/build.make:86: build/libzvbi/src/libzvbi-stamp/libzvbi-build] Error 2
make[3]: *** [CMakeFiles/Makefile2:914: CMakeFiles/libzvbi.dir/all] Error 2
make[3]: *** Waiting for unfinished jobs....
CMake Warning:
  Manually-specified variables were not used by the project:

    CMAKE_USER_MAKE_RULES_OVERRIDE_CXX
    ENABLE_STATIC
    PACKAGE_CONFIG_PATH
```