### PR TITLE
gmp: add GCC 15 patch to fix compilation as defaults to std=23

### DIFF
--- a/depends/common/gmp/0001-gmp-gcc-15-updated.patch
+++ b/depends/common/gmp/0001-gmp-gcc-15-updated.patch
@@ -1,0 +1,21 @@
+
+# HG changeset patch
+# User Marc Glisse <marc.glisse@inria.fr>
+# Date 1738186682 -3600
+# Node ID 8e7bb4ae7a18b1405ea7f9cbcda450b7d920a901
+# Parent  e84c5c785bbe8ed8c3620194e50b65adfc2f5d83
+Complete function prototype in acinclude.m4 for C23 compatibility
+
+diff -r e84c5c785bbe -r 8e7bb4ae7a18 acinclude.m4
+--- a/acinclude.m4	Wed Dec 04 18:26:27 2024 +0100
++++ b/acinclude.m4	Wed Jan 29 22:38:02 2025 +0100
+@@ -609,7 +609,7 @@
+ 
+ #if defined (__GNUC__) && ! defined (__cplusplus)
+ typedef unsigned long long t1;typedef t1*t2;
+-void g(){}
++void g(int a,t1 const*b,t1 c,t2 d,t1 const*e,int f){}
+ void h(){}
+ static __inline__ t1 e(t2 rp,t2 up,int n,t1 v0)
+ {t1 c,x,r;int i;if(v0){c=1;for(i=1;i<n;i++){x=up[i];r=x+1;rp[i]=r;}}return c;}
+

--- a/depends/common/gmp/CMakeLists.txt
+++ b/depends/common/gmp/CMakeLists.txt
@@ -27,6 +27,7 @@ if(CORE_SYSTEM_NAME STREQUAL osx OR
 
   externalproject_add(gmp
                       SOURCE_DIR ${CMAKE_SOURCE_DIR}
+                      PATCH_COMMAND autoreconf -vif
                       CONFIGURE_COMMAND
                           bash --login -c
                           "./configure \


### PR DESCRIPTION
GCC 15 defaults to std=23, causing a build failure. The first patch is from the gmp mailing list, it also "fixes the fix" for compatibility with older compilers by adding parameters.

I made the second patch after testing the first.

Fixes: https://github.com/xbmc/inputstream.ffmpegdirect/issues/351

This will allow the latest buildroot for webOS to build it