### PR TITLE
Piers gcc15 compilation fixes

### DIFF
--- a/depends/common/gmp/001-gcc15-fix-compilation.patch
+++ b/depends/common/gmp/001-gcc15-fix-compilation.patch
@@ -1,0 +1,24 @@
+From 14837bacbbd80804a11fee2016f660d132bf8aec Mon Sep 17 00:00:00 2001
+From: Marc Glisse <marc.glisse@inria.fr>
+Date: Wed, 29 Jan 2025 22:38:02 +0100
+Subject: [PATCH] Complete function prototype in acinclude.m4 for C23
+ compatibility
+
+---
+ ChangeLog    | 5 +++++
+ acinclude.m4 | 2 +-
+ 2 files changed, 6 insertions(+), 1 deletion(-)
+
+diff --git a/acinclude.m4 b/acinclude.m4
+index fddb5fb07..4fca12de2 100644
+--- a/acinclude.m4
++++ b/acinclude.m4
+@@ -609,7 +609,7 @@ GMP_PROG_CC_WORKS_PART([$1], [long long reliability test 1],
+ 
+ #if defined (__GNUC__) && ! defined (__cplusplus)
+ typedef unsigned long long t1;typedef t1*t2;
+-void g(){}
++void g(int,t1 const*,t1,t2,t1 const*,int){}
+ void h(){}
+ static __inline__ t1 e(t2 rp,t2 up,int n,t1 v0)
+ {t1 c,x,r;int i;if(v0){c=1;for(i=1;i<n;i++){x=up[i];r=x+1;rp[i]=r;}}return c;}

--- a/depends/common/gmp/CMakeLists.txt
+++ b/depends/common/gmp/CMakeLists.txt
@@ -52,6 +52,7 @@ else()
 
   externalproject_add(gmp
                       SOURCE_DIR ${CMAKE_SOURCE_DIR}
+                      PATCH_COMMAND autoreconf -vif
                       CONFIGURE_COMMAND <SOURCE_DIR>/configure
                         --prefix=${CMAKE_INSTALL_PREFIX}
                         --disable-assembly


### PR DESCRIPTION
gmp fix is based on https://github.com/gmp-mirror/gmp/commit/14837bacbbd80804a11fee2016f660d132bf8aec

i duplicated the issue and verified the fix on armv7 / aarch64 / x86_64 linux using arch.

here is the full log gmp issue
[gmp-gcc15.log](https://github.com/user-attachments/files/23972758/gmp-gcc15.log)


@phunkyfish 