### PR TITLE
change gmp download url to ftp.gnu.org

### DIFF
--- a/depends/common/gmp/gmp.txt
+++ b/depends/common/gmp/gmp.txt
@@ -1,1 +1,1 @@
-gmp https://gmplib.org/download/gmp/gmp-6.3.0.tar.xz
+gmp https://ftp.gnu.org/gnu/gmp/gmp-6.3.0.tar.xz


### PR DESCRIPTION
Current mirror url of gmp is more inaccessible that it is accessible.
Instead change it to gnu servers as it is currently for iconv

           --- LOG END ---
          error: downloading 'https://gmplib.org/download/gmp/gmp-6.3.0.tar.xz' failed
          status_code: 28
          status_string: "Timeout was reached"
          log:
          --- LOG BEGIN ---
          Host gmplib.org:443 was resolved.


@phunkyfish tagging not to get lost.