### PR TITLE
Fix building with binutils > 2.43 of Omega ffmpeg 6.0 on ARMv7

### DIFF
--- a/depends/common/ffmpeg/0006-ffmpeg-linux-binutils-2-43-label.patch
+++ b/depends/common/ffmpeg/0006-ffmpeg-linux-binutils-2-43-label.patch
@@ -1,0 +1,55 @@
+From 654bd47716c4f36719fb0f3f7fd8386d5ed0b916 Mon Sep 17 00:00:00 2001
+From: Ross Burton <ross.burton@arm.com>
+Date: Fri, 9 Aug 2024 11:32:00 +0100
+Subject: [PATCH] libavcodec/arm/mlpdsp_armv5te: fix label format to work with
+ binutils 2.43
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+binutils 2.43 has stricter validation for labels[1] and results in errors
+when building ffmpeg for armv5:
+
+src/libavcodec/arm/mlpdsp_armv5te.S:232: Error: junk at end of line, first unrecognized character is `0'
+
+Remove the leading zero in the "01" label to resolve this error.
+
+[1] https://sourceware.org/git/?p=binutils-gdb.git;a=commit;h=226749d5a6ff0d5c607d6428d6c81e1e7e7a994b
+
+Signed-off-by: Ross Burton <ross.burton@arm.com>
+Signed-off-by: Martin Storsjö <martin@martin.st>
+---
+ libavcodec/arm/mlpdsp_armv5te.S | 6 +++---
+ 1 file changed, 3 insertions(+), 3 deletions(-)
+
+diff --git a/libavcodec/arm/mlpdsp_armv5te.S b/libavcodec/arm/mlpdsp_armv5te.S
+index 4f9aa485fd21a..d31568611c30f 100644
+--- a/libavcodec/arm/mlpdsp_armv5te.S
++++ b/libavcodec/arm/mlpdsp_armv5te.S
+@@ -229,7 +229,7 @@ A .endif
+   .endif
+ 
+         // Begin loop
+-01:
++1:
+   .if TOTAL_TAPS == 0
+         // Things simplify a lot in this case
+         // In fact this could be pipelined further if it's worth it...
+@@ -241,7 +241,7 @@ A .endif
+         str     ST0, [PST, #-4]!
+         str     ST0, [PST, #4 * (MAX_BLOCKSIZE + MAX_FIR_ORDER)]
+         str     ST0, [PSAMP], #4 * MAX_CHANNELS
+-        bne     01b
++        bne     1b
+   .else
+     .if \fir_taps & 1
+       .set LOAD_REG, 1
+@@ -333,7 +333,7 @@ T       orr     AC0, AC0, AC1
+         str     ST3, [PST, #-4]!
+         str     ST2, [PST, #4 * (MAX_BLOCKSIZE + MAX_FIR_ORDER)]
+         str     ST3, [PSAMP], #4 * MAX_CHANNELS
+-        bne     01b
++        bne     1b
+   .endif
+         b       99f
+ 


### PR DESCRIPTION
Upstream bug: https://trac.ffmpeg.org/ticket/11074
Upstream fix: https://github.com/FFmpeg/FFmpeg/commit/654bd47716c4f36719fb0f3f7fd8386d5ed0b916

Error:
2025-12-17T16:21:17.8160925Z src/libavcodec/arm/mlpdsp_armv5te.S: Assembler messages:
2025-12-17T16:21:17.8161491Z src/libavcodec/arm/mlpdsp_armv5te.S:232: Error: junk at end of line, first unrecognized character is `0'
2025-12-17T16:21:17.8162013Z src/libavcodec/arm/mlpdsp_armv5te.S:367:  Info: macro invoked from here
2025-12-17T16:21:17.8162436Z src/libavcodec/arm/mlpdsp_armv5te.S:393:   Info: macro invoked from here
2025-12-17T16:21:17.8162860Z src/libavcodec/arm/mlpdsp_armv5te.S:414:    Info: macro invoked from here

Full log:
[job-logs.txt](https://github.com/user-attachments/files/24218273/job-logs.txt)

@phunkyfish 
