### PR TITLE
[depends] gmp: perform autoreconf command also on non-OSX platforms

### DIFF
--- a/depends/common/gmp/CMakeLists.txt
+++ b/depends/common/gmp/CMakeLists.txt
@@ -53,6 +53,7 @@ else()
 
   externalproject_add(gmp
                       SOURCE_DIR ${CMAKE_SOURCE_DIR}
+                      PATCH_COMMAND autoreconf -vif
                       CONFIGURE_COMMAND <SOURCE_DIR>/configure
                         --prefix=${CMAKE_INSTALL_PREFIX}
                         --disable-assembly


### PR DESCRIPTION
This is necessary so that the changes from 0001-gmp-gcc-15-updated.patch are actually used in configure step on non-OSX platforms, so that building with GCC 15 works under Linux (e.g. Debian Testing).

Maybe this also fixes https://github.com/xbmc/inputstream.ffmpegdirect/issues/362 and the problem reported at https://github.com/xbmc/inputstream.ffmpegdirect/issues/351#issuecomment-3795641734 .