### PR TITLE
Update changelog

### DIFF
--- a/inputstream.ffmpegdirect/changelog.txt
+++ b/inputstream.ffmpegdirect/changelog.txt
@@ -1,3 +1,13 @@
+v22.2.3
+- CI: Remove Win32-UWP from azure-pipelines.yml
+- gmp: perform autoreconf command also on non-OSX platforms
+
+v22.2.2
+- load zlib-1.3.1.tar.xz from mirrors
+
+v22.2.1
+- New addon setting to set ffmpeg option 'extension_picky'
+
 v22.2.0
 - Bump ffmpeg to 8.0 and add patch to merge in libpostproc plugin before ffmpeg-build
 - gmp: download from GNU Mirror


### PR DESCRIPTION
v22.2.3
- CI: Remove Win32-UWP from azure-pipelines.yml
- gmp: perform autoreconf command also on non-OSX platforms
