### PR TITLE
Fix 6s close delay on timeshift HLS streams

### DIFF
--- a/src/stream/TimeshiftStream.cpp
+++ b/src/stream/TimeshiftStream.cpp
@@ -78,6 +78,7 @@ bool TimeshiftStream::Start()
 void TimeshiftStream::Close()
 {
   m_running = false;
+  DemuxAbort();
   if (m_inputThread.joinable())
     m_inputThread.join();
 


### PR DESCRIPTION
When using `stream_mode=timeshift` with an HLS live stream, stopping playback hangs for 6+ seconds before ffmpegdirect finishes closing. The delay scales with the av_read_frame timeout, not buffer size, and is consistent on a healthy live source.

Fixes: https://github.com/xbmc/inputstream.ffmpegdirect/issues/368

## Root cause

`TimeshiftStream::Close()` sets `m_running = false` and immediately calls `m_inputThread.join()`, but never aborts the in-flight `av_read_frame()` in the reader thread.

The reader thread (`DoReadWrite`) is parked inside `FFmpegStream::DemuxRead()` → `av_read_frame()` with a 20-second timeout (`m_timeout.Set(20000)` at FFmpegStream.cpp). The FFmpeg interrupt callback only returns 1 when `m_timeout.IsTimePast()` is true — and nothing expires the timeout during close. So the join blocks until either the current HTTP I/O completes or the timeout elapses.

## Fix

Call `DemuxAbort()` before joining. `DemuxAbort()` calls `m_timeout.SetExpired()`, which makes the interrupt callback return 1, which makes `av_read_frame()` return `AVERROR_EXIT` immediately.

`StreamManager::DemuxAbort()` already uses this same pattern when delegating aborts to the active stream — `TimeshiftStream::Close()` was bypassing it by going directly to `join()`.

## Testing

Reproduced and verified on:
- inputstream.ffmpegdirect 22.2.4 (Kodi 22)
- HLS live stream from Jellyfin server
- Linux x86_64 and Android ARM v7

Before the fix: stop -> 6s+ pause before the addon finishes closing.
After the fix: stop -> close completes in well under a second.
