### PR TITLE
Fix build against ffmpeg 9 by using av_parser_parse2()

### DIFF
--- a/src/stream/FFmpegStream.cpp
+++ b/src/stream/FFmpegStream.cpp
@@ -1669,6 +1669,7 @@ void FFmpegStream::ParsePacket(AVPacket* pkt)
 
     if (parser->second->m_parserCtx &&
         parser->second->m_parserCtx->parser &&
+        parser->second->m_codecCtx &&
         !st->codecpar->extradata)
     {
       FFmpegExtraData retExtraData = GetPacketExtradata(pkt, st->codecpar);
@@ -1677,29 +1678,31 @@ void FFmpegStream::ParsePacket(AVPacket* pkt)
         st->codecpar->extradata_size = retExtraData.GetSize();
         st->codecpar->extradata = retExtraData.TakeData();
 
-        if (parser->second->m_parserCtx->parser->parser_parse)
-        {
-          parser->second->m_codecCtx->extradata = st->codecpar->extradata;
-          parser->second->m_codecCtx->extradata_size = st->codecpar->extradata_size;
-          const uint8_t* outbufptr;
-          int bufSize;
-          parser->second->m_parserCtx->flags |= PARSER_FLAG_COMPLETE_FRAMES;
-          parser->second->m_parserCtx->parser->parser_parse(parser->second->m_parserCtx,
-                                                            parser->second->m_codecCtx,
-                                                            &outbufptr, &bufSize,
-                                                            pkt->data, pkt->size);
-          parser->second->m_codecCtx->extradata = nullptr;
-          parser->second->m_codecCtx->extradata_size = 0;
+        parser->second->m_codecCtx->extradata = st->codecpar->extradata;
+        parser->second->m_codecCtx->extradata_size = st->codecpar->extradata_size;
+        uint8_t* outbufptr;
+        int bufSize;
+        parser->second->m_parserCtx->flags |= PARSER_FLAG_COMPLETE_FRAMES;
+        int ret = av_parser_parse2(parser->second->m_parserCtx, parser->second->m_codecCtx,
+                                   &outbufptr, &bufSize, pkt->data, pkt->size,
+                                   pkt->pts, pkt->dts, pkt->pos);
+        parser->second->m_codecCtx->extradata = nullptr;
+        parser->second->m_codecCtx->extradata_size = 0;
 
-          if (parser->second->m_parserCtx->width != 0)
-          {
-            st->codecpar->width = parser->second->m_parserCtx->width;
-            st->codecpar->height = parser->second->m_parserCtx->height;
-          }
-          else
-          {
-            Log(LOGLEVEL_ERROR, "CDVDDemuxFFmpeg::ParsePacket() invalid width/height");
-          }
+        if (ret < 0)
+        {
+          Log(LOGLEVEL_ERROR, "%s - error parsing packet: %d", __FUNCTION__, ret);
+          return;
+        }
+
+        if (parser->second->m_parserCtx->width != 0)
+        {
+          st->codecpar->width = parser->second->m_parserCtx->width;
+          st->codecpar->height = parser->second->m_parserCtx->height;
+        }
+        else
+        {
+          Log(LOGLEVEL_ERROR, "CDVDDemuxFFmpeg::ParsePacket() invalid width/height");
         }
       }
     }


### PR DESCRIPTION
ffmpeg 9 made `AVCodecParser::parser_parse` private, so the direct call in
`FFmpegStream::ParsePacket()` no longer compiles.

Kodi core hit this in the same function and moved to the public
`av_parser_parse2()` in xbmc/xbmc@c4913a2 (the ffmpeg 8.1 bump). This code came
from core originally (07ea26d), so this does the same here:

- drop the `if (parser->second->m_parserCtx->parser->parser_parse)` guard and
  check `m_codecCtx` in the outer `if` instead
- `const uint8_t* outbufptr` -> `uint8_t* outbufptr`
- call `av_parser_parse2()` and return early if it fails

`PARSER_FLAG_COMPLETE_FRAMES` stays set, so behaviour is unchanged. The result
matches core's current `CDVDDemuxFFmpeg::ParsePacket()`.

Builds and runs against ffmpeg 9.0.

Fixes #381

🤖 Generated with [Claude Code](https://claude.com/claude-code)
